### PR TITLE
Add nsec login to sign-in flow

### DIFF
--- a/nostrTV/ContentView.swift
+++ b/nostrTV/ContentView.swift
@@ -558,7 +558,7 @@ struct ContentView: View {
             }
         }
         .fullScreenCover(isPresented: $showLoginSheet) {
-            LoginFlowView(authManager: authManager)
+            WelcomeView(authManager: authManager)
         }
         .onAppear {
             // Update follow list when view appears

--- a/nostrTV/KeychainHelper.swift
+++ b/nostrTV/KeychainHelper.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Security
+
+enum KeychainHelper {
+    private static let nsecKey = "nostrNsecPrivateKey"
+    private static let service = Bundle.main.bundleIdentifier ?? "com.nostrtv.app"
+
+    @discardableResult
+    static func save(_ nsec: String) -> Bool {
+        guard let data = nsec.data(using: .utf8) else { return false }
+
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: nsecKey,
+            kSecValueData: data,
+            kSecAttrAccessible: kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+        ]
+
+        SecItemDelete(query as CFDictionary)
+        return SecItemAdd(query as CFDictionary, nil) == errSecSuccess
+    }
+
+    static func load() -> String? {
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: nsecKey,
+            kSecReturnData: true,
+            kSecMatchLimit: kSecMatchLimitOne
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        guard status == errSecSuccess,
+              let data = result as? Data,
+              let nsec = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+
+        return nsec
+    }
+
+    @discardableResult
+    static func delete() -> Bool {
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: nsecKey
+        ]
+        return SecItemDelete(query as CFDictionary) == errSecSuccess
+    }
+}

--- a/nostrTV/NostrAuthManager.swift
+++ b/nostrTV/NostrAuthManager.swift
@@ -45,6 +45,14 @@ class NostrAuthManager: ObservableObject {
             Task { @MainActor in
                 await restoreBunkerSession(bunkerSession)
             }
+        } else if let storedNsec = KeychainHelper.load(),
+                  let keyPair = try? NostrKeyPair(nsec: storedNsec) {
+            // Restore nsec session
+            authMethod = .nsec(keyPair: keyPair)
+            currentUser = UserSession(nip05: "", hexPubkey: keyPair.publicKeyHex)
+            isAuthenticated = true
+            loadCachedProfile()
+            isLoadingProfile = false
         }
     }
 
@@ -172,6 +180,23 @@ class NostrAuthManager: ObservableObject {
         isAuthenticated = true
     }
 
+    // MARK: - nsec Authentication
+
+    /// Authenticate directly with an nsec private key
+    @MainActor
+    func authenticateWithNsec(_ nsec: String) async throws {
+        guard let keyPair = try? NostrKeyPair(nsec: nsec) else {
+            throw NostrAuthError.invalidNsec
+        }
+
+        KeychainHelper.save(nsec)
+        authMethod = .nsec(keyPair: keyPair)
+        currentUser = UserSession(nip05: "", hexPubkey: keyPair.publicKeyHex)
+        isAuthenticated = true
+        isLoadingProfile = true
+        fetchUserData(force: true)
+    }
+
     /// Restore a bunker session on app launch (lazy — no network calls)
     /// Relay connection is deferred until the first actual signing request
     @MainActor
@@ -212,6 +237,9 @@ class NostrAuthManager: ObservableObject {
         // Clear bunker session
         bunkerSessionManager.clearSession()
 
+        // Clear nsec from Keychain
+        KeychainHelper.delete()
+
         // Clear UserDefaults
         UserDefaults.standard.removeObject(forKey: "nostrUserProfile")
         UserDefaults.standard.removeObject(forKey: "nostrUserFollowList")
@@ -230,12 +258,24 @@ class NostrAuthManager: ObservableObject {
 
     // MARK: - Event Signing
 
-    /// Sign a Nostr event using bunker (remote signing only)
+    /// Sign a Nostr event using the active auth method
     func signEvent(_ event: NostrEvent) async throws -> NostrEvent {
-        guard let bunkerClient = bunkerClient else {
-            throw NostrAuthError.bunkerNotConnected
+        switch authMethod {
+        case .bunker:
+            guard let bunkerClient = bunkerClient else {
+                throw NostrAuthError.bunkerNotConnected
+            }
+            return try await bunkerClient.signEvent(event)
+        case .nsec(let keyPair):
+            return try nostrSDKClient.createSignedEvent(
+                kind: event.kind,
+                content: event.content ?? "",
+                tags: event.tags,
+                using: keyPair
+            )
+        case nil:
+            throw NostrAuthError.notAuthenticated
         }
-        return try await bunkerClient.signEvent(event)
     }
 }
 
@@ -244,6 +284,7 @@ class NostrAuthManager: ObservableObject {
 enum NostrAuthError: LocalizedError {
     case notAuthenticated
     case bunkerNotConnected
+    case invalidNsec
 
     var errorDescription: String? {
         switch self {
@@ -251,6 +292,8 @@ enum NostrAuthError: LocalizedError {
             return "User is not authenticated"
         case .bunkerNotConnected:
             return "Bunker client not connected"
+        case .invalidNsec:
+            return "Invalid nsec key. Please check and try again."
         }
     }
 }
@@ -259,6 +302,7 @@ enum NostrAuthError: LocalizedError {
 
 enum AuthMethod {
     case bunker(session: BunkerSession)
+    case nsec(keyPair: NostrKeyPair)
 }
 
 struct UserSession {

--- a/nostrTV/NsecLoginView.swift
+++ b/nostrTV/NsecLoginView.swift
@@ -1,0 +1,127 @@
+import SwiftUI
+
+struct NsecLoginView: View {
+    @ObservedObject var authManager: NostrAuthManager
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var nsecInput: String = ""
+    @State private var isLoading: Bool = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        ZStack {
+            Color.coveBackground
+                .ignoresSafeArea()
+
+            HStack(spacing: 80) {
+                // Left column: input form
+                VStack(spacing: 40) {
+                    Spacer()
+
+                    Text("Cove")
+                        .font(.coveTitle)
+                        .foregroundColor(.coveAccent)
+
+                    Text("Sign in with nsec")
+                        .font(.system(size: 32, weight: .regular, design: .rounded))
+                        .foregroundColor(.coveSecondary)
+
+                    VStack(spacing: 16) {
+                        SecureField("nsec1...", text: $nsecInput)
+                            .font(.system(size: 24, design: .monospaced))
+                            .foregroundColor(.white)
+                            .padding()
+                            .background(Color.coveOverlay)
+                            .cornerRadius(CoveUI.badgeCornerRadius)
+                            .frame(width: 520)
+                            .disabled(isLoading)
+
+                        if let error = errorMessage {
+                            Text(error)
+                                .font(.coveCaption)
+                                .foregroundColor(.coveGold)
+                                .multilineTextAlignment(.center)
+                                .frame(width: 520)
+                        }
+                    }
+                    .frame(height: 120)
+
+                    if isLoading {
+                        ProgressView()
+                            .scaleEffect(1.5)
+                            .tint(.coveAccent)
+                    } else {
+                        Button(action: signIn) {
+                            Text("Sign In")
+                                .font(.coveSubheading)
+                                .foregroundColor(.white)
+                                .frame(width: 300, height: 70)
+                                .background(nsecInput.isEmpty ? Color.coveAccent.opacity(0.4) : Color.coveAccent)
+                                .cornerRadius(CoveUI.smallCornerRadius)
+                        }
+                        .buttonStyle(.plain)
+                        .disabled(nsecInput.isEmpty)
+                    }
+
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                    .buttonStyle(.bordered)
+                    .tint(.coveSecondary)
+                    .font(.coveSubheading)
+                    .controlSize(.large)
+
+                    Spacer()
+                }
+                .frame(maxWidth: .infinity)
+
+                // Right column: explanation
+                VStack(spacing: 30) {
+                    Spacer()
+
+                    Image(systemName: "lock.fill")
+                        .font(.system(size: 80))
+                        .foregroundColor(.coveAccent)
+
+                    Text("Your private key")
+                        .font(.system(size: 28, weight: .semibold, design: .rounded))
+                        .foregroundColor(.white)
+
+                    Text("Enter your Nostr private key (nsec) to sign in directly. Your key is stored securely on this device and never sent to any server.")
+                        .font(.coveBody)
+                        .foregroundColor(.coveSecondary)
+                        .multilineTextAlignment(.center)
+                        .frame(maxWidth: 500)
+
+                    Text("Keep your nsec secret — it controls your Nostr identity.")
+                        .font(.coveCaption)
+                        .foregroundColor(.coveGold)
+                        .multilineTextAlignment(.center)
+                        .frame(maxWidth: 500)
+
+                    Spacer()
+                }
+                .frame(maxWidth: .infinity)
+            }
+            .padding(60)
+        }
+    }
+
+    private func signIn() {
+        let trimmed = nsecInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        isLoading = true
+        errorMessage = nil
+
+        Task { @MainActor in
+            do {
+                try await authManager.authenticateWithNsec(trimmed)
+                dismiss()
+            } catch {
+                isLoading = false
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+}

--- a/nostrTV/ProfileConfirmationView.swift
+++ b/nostrTV/ProfileConfirmationView.swift
@@ -52,8 +52,8 @@ struct ProfileConfirmationView: View {
                         .font(.system(size: 36, weight: .semibold))
                         .foregroundColor(.white)
 
-                    // NIP-05 identifier
-                    if let nip05 = authManager.currentUser?.nip05 {
+                    // NIP-05 identifier (omit for nsec logins where nip05 is empty)
+                    if let nip05 = authManager.currentUser?.nip05, !nip05.isEmpty {
                         Text(nip05)
                             .font(.system(size: 22))
                             .foregroundColor(.coveAccent)

--- a/nostrTV/WelcomeView.swift
+++ b/nostrTV/WelcomeView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct WelcomeView: View {
     @ObservedObject var authManager: NostrAuthManager
     @State private var showBunkerLogin: Bool = false
+    @State private var showNsecLogin: Bool = false
 
     var body: some View {
         VStack(spacing: 40) {
@@ -23,10 +24,6 @@ struct WelcomeView: View {
                 .font(.system(size: 32, weight: .regular, design: .rounded))
                 .foregroundColor(.coveSecondary)
 
-            Text("Use your nsec bunker to sign in")
-                .font(.coveBody)
-                .foregroundColor(.coveSecondary.opacity(0.7))
-
             // Error message
             if let error = authManager.errorMessage {
                 Text(error)
@@ -36,25 +33,49 @@ struct WelcomeView: View {
                     .padding(.horizontal, 40)
             }
 
-            // Bunker login button
-            Button(action: { showBunkerLogin = true }) {
-                HStack(spacing: 12) {
-                    Image(systemName: "qrcode")
-                        .font(.system(size: 24))
-                    Text("Sign in with nsec bunker")
-                        .font(.coveSubheading)
+            VStack(spacing: 20) {
+                // Primary: Bunker login
+                Button(action: { showBunkerLogin = true }) {
+                    HStack(spacing: 12) {
+                        Image(systemName: "qrcode")
+                            .font(.system(size: 24))
+                        Text("Sign in with nsec bunker")
+                            .font(.coveSubheading)
+                    }
+                    .foregroundColor(.white)
+                    .frame(width: 500, height: 70)
+                    .background(Color.coveAccent)
+                    .cornerRadius(CoveUI.smallCornerRadius)
                 }
-                .foregroundColor(.white)
-                .frame(width: 500, height: 70)
-                .background(Color.coveAccent)
-                .cornerRadius(CoveUI.smallCornerRadius)
+                .buttonStyle(.plain)
+
+                // Secondary: nsec key login
+                Button(action: { showNsecLogin = true }) {
+                    HStack(spacing: 12) {
+                        Image(systemName: "key.fill")
+                            .font(.system(size: 24))
+                        Text("Sign in with nsec key")
+                            .font(.coveSubheading)
+                    }
+                    .foregroundColor(.coveSecondary)
+                    .frame(width: 500, height: 70)
+                    .background(Color.coveOverlay)
+                    .cornerRadius(CoveUI.smallCornerRadius)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: CoveUI.smallCornerRadius)
+                            .stroke(Color.coveSecondary.opacity(0.4), lineWidth: 1)
+                    )
+                }
+                .buttonStyle(.plain)
             }
-            .buttonStyle(.plain)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color.coveBackground)
         .fullScreenCover(isPresented: $showBunkerLogin) {
             BunkerLoginView(authManager: authManager)
+        }
+        .fullScreenCover(isPresented: $showNsecLogin) {
+            NsecLoginView(authManager: authManager)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Added nsec private key login as a sign-in option alongside the existing nsec bunker method
- Wired `WelcomeView` into the login sheet so users see both options (was previously bypassing to bunker-only `LoginFlowView`)
- Nsec keys are stored securely in Keychain (`KeychainHelper`)

## Test plan
- [ ] Tap the profile tab while signed out — confirm both "Sign in with nsec bunker" and "Sign in with nsec key" options appear
- [ ] Sign in with a valid nsec key — confirm profile loads and you are logged in
- [ ] Sign in with an invalid nsec — confirm error message is shown
- [ ] Sign in via bunker — confirm existing flow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)