### PR TITLE
Consistent login UI across all entry points

### DIFF
--- a/nostrTV/ProfileSettingsView.swift
+++ b/nostrTV/ProfileSettingsView.swift
@@ -52,7 +52,7 @@ struct ProfileSettingsView: View {
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .fullScreenCover(isPresented: $showLoginSheet) {
-                    LoginFlowView(authManager: authManager)
+                    WelcomeView(authManager: authManager)
                 }
             } else if let profile = authManager.currentProfile {
                 VStack(alignment: .center, spacing: 40) {


### PR DESCRIPTION
## Summary
- Profile tab's "Log In" button now shows `WelcomeView` (both nsec bunker + nsec key options), matching the Following tab
- Previously `ProfileSettingsView` was still showing the old `LoginFlowView` (bunker only)

## Test plan
- [ ] Tap "Log In" from the Following tab — confirm WelcomeView with both options appears
- [ ] Tap "Log In" from the Profile tab — confirm the same WelcomeView appears
- [ ] Sign in via nsec key from both entry points — confirm it works

🤖 Generated with [Claude Code](https://claude.com/claude-code)