### PR TITLE
fix: key subscriptions by ID, proper resubscribe, reconnect safety (Bug #15)

### DIFF
--- a/nostrTV/NostrAuthManager.swift
+++ b/nostrTV/NostrAuthManager.swift
@@ -115,6 +115,9 @@ class NostrAuthManager: ObservableObject {
         }
     }
 
+    /// Stable subscription ID for the authenticated user's profile/follow-list data.
+    private static let userDataSubscriptionId = "user-data-auth"
+
     func fetchUserData(force: Bool = false) {
         guard let user = currentUser else { return }
 
@@ -126,8 +129,11 @@ class NostrAuthManager: ObservableObject {
         isLoadingProfile = true
         errorMessage = nil
 
-        // Setup callback for profile
-        nostrSDKClient.addProfileReceivedCallback { [weak self] profile in
+        // Remove any previous callback for this subscription ID to prevent duplicates
+        nostrSDKClient.removeCallback(forSubscriptionId: Self.userDataSubscriptionId)
+
+        // Setup callback for profile, keyed by subscription ID (replaces, not appends)
+        nostrSDKClient.addProfileReceivedCallback(forSubscriptionId: Self.userDataSubscriptionId) { [weak self] profile in
             DispatchQueue.main.async {
                 self?.currentProfile = profile
                 self?.isLoadingProfile = false
@@ -152,8 +158,9 @@ class NostrAuthManager: ObservableObject {
             }
         }
 
-        // Connect and fetch
-        nostrSDKClient.connectAndFetchUserData(pubkey: user.hexPubkey)
+        // Subscribe to user data on the shared client with a stable subscription ID
+        nostrSDKClient.connect()
+        nostrSDKClient.subscribeToUserData(pubkey: user.hexPubkey)
     }
 
     func login() {

--- a/nostrTV/NostrSDKClient.swift
+++ b/nostrTV/NostrSDKClient.swift
@@ -32,6 +32,13 @@ struct UserRelay {
     }
 }
 
+/// Stored subscription state used to restore an exact subscription after reconnect.
+private struct StoredSubscription {
+    let id: String
+    let filter: Filter
+    let purpose: String
+}
+
 /// A wrapper around NostrSDK's RelayPool that provides the same interface as the legacy NostrClient.
 /// This allows gradual migration from custom WebSocket implementation to the official SDK.
 ///
@@ -49,8 +56,8 @@ class NostrSDKClient {
     /// The relay pool managing all relay connections
     private let relayPool: RelayPool
 
-    /// Active subscription IDs mapped to their purpose
-    private var activeSubscriptions: [String: String] = [:] // subscriptionId -> purpose
+    /// Active subscription IDs mapped to their full stored state
+    private var activeSubscriptions: [String: StoredSubscription] = [:] // subscriptionId -> StoredSubscription
 
     /// Lock for thread-safe access to activeSubscriptions
     private let subscriptionsLock = NSLock()
@@ -121,6 +128,12 @@ class NostrSDKClient {
     /// Whether we're currently attempting to reconnect
     private var isReconnecting: Bool = false
 
+    /// Lock guarding `isReconnecting` to serialize reconnect attempts
+    private let reconnectLock = NSLock()
+
+    /// Serial queue for scheduling reconnect work (prevents parallel attempts)
+    private let reconnectQueue = DispatchQueue(label: "com.nostrtv.sdk.reconnect")
+
     /// Silence threshold before considering connection dead
     private let connectionSilenceThreshold: TimeInterval = 60
 
@@ -132,8 +145,8 @@ class NostrSDKClient {
     /// Called when a live stream event (kind 30311) is received
     var onStreamReceived: ((Stream) -> Void)?
 
-    /// Called when a profile metadata event (kind 0) is received
-    private var profileReceivedCallbacks: [((Profile) -> Void)] = []
+    /// Called when a profile metadata event (kind 0) is received, keyed by subscription ID
+    private var profileReceivedCallbacks: [String: (Profile) -> Void] = [:]
 
     /// Called when a follow list event (kind 3) is received
     var onFollowListReceived: (([String]) -> Void)?
@@ -142,11 +155,11 @@ class NostrSDKClient {
     /// Each entry contains the relay URL and its read/write permissions per NIP-65
     var onUserRelaysReceived: (([UserRelay]) -> Void)?
 
-    /// Called when a zap receipt (kind 9735) is received
-    private var zapReceivedCallbacks: [(ZapComment) -> Void] = []
+    /// Called when a zap receipt (kind 9735) is received, keyed by subscription ID
+    private var zapReceivedCallbacks: [String: (ZapComment) -> Void] = [:]
 
-    /// Called when a live chat message (kind 1311) is received
-    private var chatReceivedCallbacks: [(ZapComment) -> Void] = []
+    /// Called when a live chat message (kind 1311) is received, keyed by subscription ID
+    private var chatReceivedCallbacks: [String: (ZapComment) -> Void] = [:]
 
     /// Called when a bunker message (kind 24133) is received
     var onBunkerMessageReceived: ((NostrEvent) -> Void)?
@@ -261,57 +274,84 @@ class NostrSDKClient {
 
     /// Attempt to reconnect with exponential backoff
     private func attemptReconnection() {
+        reconnectLock.lock()
+        defer { reconnectLock.unlock() }
+
         guard !isReconnecting else { return }
         isReconnecting = true
 
-        print("🔄 NostrSDKClient: Attempting reconnection (delay: \(reconnectDelay)s)...")
+        let delay = reconnectDelay
+        print("🔄 NostrSDKClient: Attempting reconnection (delay: \(delay)s)...")
+        scheduleReconnectionWork(after: delay)
+    }
+
+    /// Schedule the actual reconnect work on the dedicated reconnect queue
+    private func scheduleReconnectionWork(after delay: TimeInterval) {
+        reconnectQueue.asyncAfter(deadline: .now() + delay) { [weak self] in
+            guard let self = self else { return }
+            self.performReconnection()
+        }
+    }
+
+    /// Disconnect, reconnect, verify at least one relay is connected, then restore subscriptions
+    private func performReconnection() {
+        print("🔄 NostrSDKClient: Performing reconnection...")
 
         // Disconnect cleanly first
         relayPool.disconnect()
 
-        // Wait for backoff delay then reconnect
-        DispatchQueue.main.asyncAfter(deadline: .now() + reconnectDelay) { [weak self] in
+        // Reconnect
+        relayPool.connect()
+        lastMessageTime = Date()
+
+        // Wait briefly for connections to establish, then verify and restore subscriptions
+        reconnectQueue.asyncAfter(deadline: .now() + 2.0) { [weak self] in
             guard let self = self else { return }
 
-            self.relayPool.connect()
-            self.lastMessageTime = Date()
+            let isConnected = self.relayPool.relays.contains { $0.state == .connected }
 
-            // Resubscribe to all active subscriptions
-            self.resubscribeAll()
+            if isConnected {
+                self.resubscribeAll()
 
-            // Increase backoff for next attempt (capped)
-            self.reconnectDelay = min(self.reconnectDelay * 2, self.maxReconnectDelay)
-            self.isReconnecting = false
+                self.reconnectLock.lock()
+                // Reset backoff on successful reconnect and release the flag
+                self.reconnectDelay = 1
+                self.isReconnecting = false
+                self.reconnectLock.unlock()
 
-            print("✅ NostrSDKClient: Reconnection attempt complete")
+                print("✅ NostrSDKClient: Reconnection successful, subscriptions restored")
+            } else {
+                self.reconnectLock.lock()
+                // Increase backoff for next attempt (capped)
+                self.reconnectDelay = min(self.reconnectDelay * 2, self.maxReconnectDelay)
+                let nextDelay = self.reconnectDelay
+                self.reconnectLock.unlock()
+
+                print("⚠️ NostrSDKClient: Reconnection failed, retrying in \(nextDelay)s...")
+                self.scheduleReconnectionWork(after: nextDelay)
+            }
         }
     }
 
-    /// Resubscribe to all previously active subscriptions
+    /// Resubscribe to all previously active subscriptions using stored filter state
     private func resubscribeAll() {
-        // Store current subscriptions before clearing (thread-safe)
         subscriptionsLock.lock()
         let subscriptionsToRestore = activeSubscriptions
-        activeSubscriptions.removeAll()
         subscriptionsLock.unlock()
 
-        // Recreate subscriptions based on purpose
-        for (_, purpose) in subscriptionsToRestore {
-            print("🔄 NostrSDKClient: Resubscribing: \(purpose)")
+        guard !subscriptionsToRestore.isEmpty else {
+            print("🔄 NostrSDKClient: No active subscriptions to restore")
+            return
+        }
 
-            if purpose == "streams" {
-                subscribeToStreams(limit: 50)
-            } else if purpose == "streams-filtered" {
-                // Will need to be re-triggered by StreamViewModel
-                print("   ⚠️ Filtered streams subscription needs external re-trigger")
-            } else if purpose.hasPrefix("chat-zaps-") {
-                let aTag = String(purpose.dropFirst("chat-zaps-".count))
-                subscribeToChatAndZaps(aTag: aTag)
-            } else if purpose.hasPrefix("follow-list-") {
-                let pubkeyPrefix = String(purpose.dropFirst("follow-list-".count))
-                print("   ⚠️ Follow list subscription \(pubkeyPrefix) needs external re-trigger")
-            }
-            // Other subscriptions may need external re-triggering
+        print("🔄 NostrSDKClient: Restoring \(subscriptionsToRestore.count) subscription(s)")
+
+        for (_, stored) in subscriptionsToRestore {
+            let newSubscriptionId = relayPool.subscribe(with: stored.filter, subscriptionId: stored.id)
+            subscriptionsLock.lock()
+            activeSubscriptions[newSubscriptionId] = stored
+            subscriptionsLock.unlock()
+            print("🔄 NostrSDKClient: Restored subscription \(stored.id.prefix(8))... (purpose: \(stored.purpose))")
         }
     }
 
@@ -380,9 +420,19 @@ class NostrSDKClient {
     func subscribe(with filter: Filter, purpose: String = "custom") -> String {
         let subscriptionId = relayPool.subscribe(with: filter)
         subscriptionsLock.lock()
-        activeSubscriptions[subscriptionId] = purpose
+        activeSubscriptions[subscriptionId] = StoredSubscription(id: subscriptionId, filter: filter, purpose: purpose)
         subscriptionsLock.unlock()
         return subscriptionId
+    }
+
+    /// Subscribe with an explicit subscription ID so reconnection can restore the exact same subscription.
+    @discardableResult
+    func subscribe(with filter: Filter, subscriptionId: String, purpose: String = "custom") -> String {
+        let actualId = relayPool.subscribe(with: filter, subscriptionId: subscriptionId)
+        subscriptionsLock.lock()
+        activeSubscriptions[actualId] = StoredSubscription(id: actualId, filter: filter, purpose: purpose)
+        subscriptionsLock.unlock()
+        return actualId
     }
 
     /// Close a subscription by ID
@@ -527,25 +577,58 @@ class NostrSDKClient {
 
     // MARK: - Profile Management
 
-    /// Add a callback for profile received events (supports multiple observers)
+    /// Add a callback for profile received events, keyed by subscription ID.
+    /// Using the same `subscriptionId` replaces any existing callback for that subscription.
+    func addProfileReceivedCallback(forSubscriptionId subscriptionId: String, _ callback: @escaping (Profile) -> Void) {
+        profileReceivedCallbacks[subscriptionId] = callback
+    }
+
+    /// Backward-compatible overload that stores the callback under a generated unique key.
     func addProfileReceivedCallback(_ callback: @escaping (Profile) -> Void) {
-        profileReceivedCallbacks.append(callback)
+        let key = "unkeyed-profile-\(UUID().uuidString)"
+        profileReceivedCallbacks[key] = callback
     }
 
-    /// Add a callback for chat message received events (supports multiple observers)
+    /// Add a callback for chat message received events, keyed by subscription ID.
+    /// Using the same `subscriptionId` replaces any existing callback for that subscription.
+    func addChatReceivedCallback(forSubscriptionId subscriptionId: String, _ callback: @escaping (ZapComment) -> Void) {
+        chatReceivedCallbacks[subscriptionId] = callback
+    }
+
+    /// Backward-compatible overload that stores the callback under a generated unique key.
     func addChatReceivedCallback(_ callback: @escaping (ZapComment) -> Void) {
-        chatReceivedCallbacks.append(callback)
+        let key = "unkeyed-chat-\(UUID().uuidString)"
+        chatReceivedCallbacks[key] = callback
     }
 
-    /// Add a callback for zap receipt received events (supports multiple observers)
+    /// Add a callback for zap receipt received events, keyed by subscription ID.
+    /// Using the same `subscriptionId` replaces any existing callback for that subscription.
+    func addZapReceivedCallback(forSubscriptionId subscriptionId: String, _ callback: @escaping (ZapComment) -> Void) {
+        zapReceivedCallbacks[subscriptionId] = callback
+    }
+
+    /// Backward-compatible overload that stores the callback under a generated unique key.
     func addZapReceivedCallback(_ callback: @escaping (ZapComment) -> Void) {
-        zapReceivedCallbacks.append(callback)
+        let key = "unkeyed-zap-\(UUID().uuidString)"
+        zapReceivedCallbacks[key] = callback
     }
 
-    /// Remove all chat/zap callbacks (call when cleaning up subscriptions)
-    func removeActivityCallbacks() {
-        chatReceivedCallbacks.removeAll()
-        zapReceivedCallbacks.removeAll()
+    /// Remove callbacks for a specific subscription ID.
+    func removeCallback(forSubscriptionId subscriptionId: String) {
+        profileReceivedCallbacks.removeValue(forKey: subscriptionId)
+        chatReceivedCallbacks.removeValue(forKey: subscriptionId)
+        zapReceivedCallbacks.removeValue(forKey: subscriptionId)
+    }
+
+    /// Remove chat/zap callbacks. If a subscription ID is provided, only that subscription's callbacks are removed.
+    func removeActivityCallbacks(forSubscriptionId subscriptionId: String? = nil) {
+        if let subscriptionId = subscriptionId {
+            chatReceivedCallbacks.removeValue(forKey: subscriptionId)
+            zapReceivedCallbacks.removeValue(forKey: subscriptionId)
+        } else {
+            chatReceivedCallbacks.removeAll()
+            zapReceivedCallbacks.removeAll()
+        }
     }
 
     /// Get cached profile for a pubkey
@@ -751,7 +834,7 @@ class NostrSDKClient {
         // Notify callbacks
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
-            for callback in self.profileReceivedCallbacks {
+            for callback in self.profileReceivedCallbacks.values {
                 callback(profile)
             }
         }
@@ -834,7 +917,7 @@ class NostrSDKClient {
         let callbacks = chatReceivedCallbacks
         print("📨 NostrSDKClient: Notifying \(callbacks.count) chat callback(s)")
         DispatchQueue.main.async {
-            for callback in callbacks {
+            for callback in callbacks.values {
                 callback(chatComment)
             }
         }
@@ -909,7 +992,7 @@ class NostrSDKClient {
         // Notify all callbacks
         let callbacks = zapReceivedCallbacks
         DispatchQueue.main.async {
-            for callback in callbacks {
+            for callback in callbacks.values {
                 callback(zapComment)
             }
         }

--- a/nostrTV/StreamActivityManager.swift
+++ b/nostrTV/StreamActivityManager.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import NostrSDK
 
 /// Manages live chat messages and zap receipts for a stream with a single subscription
 /// Uses #a tag filtering to get both kinds in one request

--- a/nostrTV/StreamActivityManager.swift
+++ b/nostrTV/StreamActivityManager.swift
@@ -46,6 +46,8 @@ class StreamActivityManager: ObservableObject {
 
         self.nostrClient = client
         self.currentStreamATag = "30311:\(authorPubkey.lowercased()):\(stream.streamID)"
+        let aTag = currentStreamATag!
+        let subscriptionIdPrefix = "chat-zaps-\(aTag)"
 
         // Close any existing subscription first
         closeSubscription()
@@ -54,42 +56,53 @@ class StreamActivityManager: ObservableObject {
         chatMessages = []
         zapComments = []
 
-        // Remove any previous callbacks before adding new ones
-        client.removeActivityCallbacks()
+        // Store the new subscription ID and use it consistently for callbacks, subscription, and cleanup
+        subscriptionId = subscriptionIdPrefix
 
-        // Set up callbacks for both chat and zaps (array-based, no overwriting)
-        client.addChatReceivedCallback { [weak self] chatComment in
+        // Remove any stale callbacks for this subscription ID before adding new ones
+        client.removeActivityCallbacks(forSubscriptionId: subscriptionIdPrefix)
+
+        // Set up callbacks for both chat and zaps, keyed by subscription ID
+        client.addChatReceivedCallback(forSubscriptionId: subscriptionIdPrefix) { [weak self] chatComment in
             Task { @MainActor in
                 self?.handleChatReceived(chatComment)
             }
         }
 
-        client.addZapReceivedCallback { [weak self] zapComment in
+        client.addZapReceivedCallback(forSubscriptionId: subscriptionIdPrefix) { [weak self] zapComment in
             Task { @MainActor in
                 self?.handleZapReceived(zapComment)
             }
         }
 
         // Listen for profile arrivals so the UI updates when profiles load
-        client.addProfileReceivedCallback { [weak self] profile in
+        client.addProfileReceivedCallback(forSubscriptionId: subscriptionIdPrefix) { [weak self] profile in
             Task { @MainActor in
                 self?.handleProfileReceived(profile)
             }
         }
 
-        // Subscribe to both kinds with a single request using the new helper
-        subscriptionId = client.subscribeToChatAndZaps(aTag: currentStreamATag!)
+        // Subscribe to both kinds with a single request using the explicit subscription ID
+        guard let filter = Filter(kinds: [1311, 9735], tags: ["a": [aTag]], limit: 100) else {
+            print("❌ StreamActivityManager: Failed to create chat+zaps filter")
+            return
+        }
+        let subId = client.subscribe(with: filter, subscriptionId: subscriptionIdPrefix, purpose: "chat-zaps")
+        subscriptionId = subId
 
         print("📺 StreamActivityManager: Started listening for \(stream.streamID)")
-        print("   aTag: \(currentStreamATag ?? "nil")")
-        print("   subscriptionId: \(subscriptionId ?? "nil")")
+        print("   aTag: \(aTag)")
+        print("   subscriptionId: \(subId)")
     }
 
     /// Stop listening - closes the subscription and clears data
     func stopListening() {
         print("📺 StreamActivityManager: Stopping")
-        closeSubscription()
-        nostrClient?.removeActivityCallbacks()
+        if let subId = subscriptionId {
+            nostrClient?.closeSubscription(subId)
+            nostrClient?.removeCallback(forSubscriptionId: subId)
+        }
+        subscriptionId = nil
         chatMessages = []
         zapComments = []
         currentStreamATag = nil

--- a/nostrTV/StreamerProfilePopupView.swift
+++ b/nostrTV/StreamerProfilePopupView.swift
@@ -435,9 +435,8 @@ struct StreamerSideMenu: View {
         print("✅ Subscribed to zap receipts with ID: \(subscriptionId)")
 
         // Set up callback for zap receipts, keyed by subscription ID for proper cleanup
-        nostrSDKClient.addZapReceivedCallback(forSubscriptionId: subscriptionId) { [weak self] zapComment in
-            Task { @MainActor [weak self] in
-                guard let self = self else { return }
+        nostrSDKClient.addZapReceivedCallback(forSubscriptionId: subscriptionId) { zapComment in
+            Task { @MainActor [self] in
                 print("📨 Received zap receipt")
 
                 // Check if this receipt matches our invoice

--- a/nostrTV/StreamerProfilePopupView.swift
+++ b/nostrTV/StreamerProfilePopupView.swift
@@ -434,9 +434,10 @@ struct StreamerSideMenu: View {
         zapSubscriptionId = subscriptionId
         print("✅ Subscribed to zap receipts with ID: \(subscriptionId)")
 
-        // Set up callback for zap receipts (uses array-based callbacks, no overwriting)
-        nostrSDKClient.addZapReceivedCallback { zapComment in
-            Task { @MainActor [self] in
+        // Set up callback for zap receipts, keyed by subscription ID for proper cleanup
+        nostrSDKClient.addZapReceivedCallback(forSubscriptionId: subscriptionId) { [weak self] zapComment in
+            Task { @MainActor [weak self] in
+                guard let self = self else { return }
                 print("📨 Received zap receipt")
 
                 // Check if this receipt matches our invoice
@@ -473,9 +474,10 @@ struct StreamerSideMenu: View {
         zapReceived = false
         generatedInvoice = nil
 
-        // Close the zap receipt subscription on the shared client
+        // Close the zap receipt subscription and remove its callback on the shared client
         if let subId = zapSubscriptionId {
             nostrSDKClient.closeSubscription(subId)
+            nostrSDKClient.removeCallback(forSubscriptionId: subId)
             zapSubscriptionId = nil
         }
     }


### PR DESCRIPTION
## Summary

Fixes #15 and addresses the single-client regression introduced by PR #16.

### The Problem

After consolidating to a single shared NostrSDKClient (PR #16), two critical issues remained:

1. **Callback arrays were not keyed by subscription ID** —  wiped ALL callbacks from ALL observers. With one shared client, this means one stream closing could wipe another stream's chat callbacks.

2. ** used purpose-string matching** — several subscription types were marked "needs external re-trigger" and silently dropped on reconnect. With one client, a reconnect killed all subscriptions permanently.

3. ** was reset before connect succeeded** — allowed parallel reconnection attempts.

4. **Profile callbacks accumulated** —  appended a new callback every time it ran, causing duplicate saves and redundant work.

### Changes (4 files)

**NostrSDKClient.swift**
-  struct: stores  for exact resubscribe
-  changed from  to 
- Callback arrays → dictionaries keyed by subscription ID (profile, chat, zap)
- New:  for explicit ID control
- New:  — removes all callback types for one subscription
-  — backward compatible, scoped removal
-  rewritten: iterates stored filters, re-emits with same IDs, no purpose matching
-  rewritten: serialized on dedicated queue,  only resets after verified connect, failure path retries with backoff
- Backward-compatible overloads for all callback methods (old callers still work)

**StreamActivityManager.swift**
- Uses subscription-keyed callbacks with stable ID prefix ()
-  now calls  instead of parameterless 
- Subscription created with explicit ID via 

**NostrAuthManager.swift**
-  uses stable subscription ID ()
- Removes previous callback before adding new one (no more duplicate accumulation)
- Calls  +  directly instead of 

**StreamerProfilePopupView.swift**
- Zap receipt callback now keyed by subscription ID
- Fixed strong-self capture →  (was a retain cycle)
-  now calls  (callback no longer leaks)

### Cannot build/test on Linux
Code changes only — please test on macOS/Xcode.