### PR TITLE
fix: load profile deterministically after bunker login (Bug #14)

### DIFF
--- a/nostrTV/NostrAuthManager.swift
+++ b/nostrTV/NostrAuthManager.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Combine
+import NostrSDK
 
 class NostrAuthManager: ObservableObject {
     @Published var isAuthenticated: Bool = false
@@ -141,8 +142,11 @@ class NostrAuthManager: ObservableObject {
             }
         }
 
-        // Setup callback for follow list
-        nostrSDKClient.onFollowListReceived = { [weak self] follows in
+        // Setup callback for follow list, keyed by the same subscription ID so it
+        // is delivered when this subscription's kind-3 events arrive. Using the
+        // keyed API prevents StreamViewModel (or any other component) from
+        // overwriting this handler via the legacy `onFollowListReceived` property.
+        nostrSDKClient.addFollowListReceivedCallback(forSubscriptionId: Self.userDataSubscriptionId) { [weak self] follows in
             DispatchQueue.main.async {
                 self?.followList = follows
                 self?.saveFollowListToCache(follows)
@@ -158,9 +162,26 @@ class NostrAuthManager: ObservableObject {
             }
         }
 
-        // Subscribe to user data on the shared client with a stable subscription ID
+        // Subscribe to user data on the shared client using the SAME subscription
+        // ID as the callbacks above. This is the Bug #14 fix: previously
+        // `subscribeToUserData(pubkey:)` generated a random UUID subscription ID,
+        // so the callback (keyed to `userDataSubscriptionId`) and the subscription
+        // were on different keys — the callback fired for every profile event but
+        // there was no guarantee a subscription for *this* pubkey was active when
+        // `authenticateWithBunker` completed. By making the subscription ID
+        // deterministic and equal to the callback key, the subscription and
+        // callback are linked: when the subscription fires, the callback receives
+        // the event.
+        guard let filter = Filter(authors: [user.hexPubkey], kinds: [0, 3], limit: 2) else {
+            print("❌ NostrAuthManager: Failed to create user data filter for \(user.hexPubkey.prefix(16))...")
+            isLoadingProfile = false
+            errorMessage = "Failed to load profile. Using cached data if available."
+            return
+        }
         nostrSDKClient.connect()
-        nostrSDKClient.subscribeToUserData(pubkey: user.hexPubkey)
+        nostrSDKClient.subscribe(with: filter,
+                                 subscriptionId: Self.userDataSubscriptionId,
+                                 purpose: "user-data-auth")
     }
 
     func login() {
@@ -197,7 +218,14 @@ class NostrAuthManager: ObservableObject {
         // Update user session
         currentUser = UserSession(nip05: "bunker:\(bunkerPubkey.prefix(8))...", hexPubkey: userPubkey)
 
-        // Fetch profile data
+        // Ensure the shared relay pool is connecting before we subscribe for the
+        // user's profile/follow list. Without this, `fetchUserData` may issue a
+        // subscription on a client whose relays have not started connecting yet,
+        // and the profile event can be missed until an app restart (Bug #14).
+        nostrSDKClient.connect()
+
+        // Fetch profile data — now deterministic: the subscription is created with
+        // `userDataSubscriptionId` as both the subscription ID and callback key.
         isLoadingProfile = true
         fetchUserData(force: true)
 

--- a/nostrTV/NostrSDKClient.swift
+++ b/nostrTV/NostrSDKClient.swift
@@ -148,8 +148,32 @@ class NostrSDKClient {
     /// Called when a profile metadata event (kind 0) is received, keyed by subscription ID
     private var profileReceivedCallbacks: [String: (Profile) -> Void] = [:]
 
-    /// Called when a follow list event (kind 3) is received
-    var onFollowListReceived: (([String]) -> Void)?
+    /// Called when a follow list event (kind 3) is received, keyed by subscription ID.
+    /// Using the same `subscriptionId` replaces any existing callback for that subscription.
+    private var followListReceivedCallbacks: [String: ([String]) -> Void] = [:]
+
+    /// Special key used to back the backward-compatible `onFollowListReceived` property
+    /// so it does not collide with subscription-keyed callbacks.
+    private static let legacyFollowListCallbackKey = "legacy-onFollowListReceived"
+
+    /// Backward-compatible single closure for follow list events.
+    /// Setting it stores the closure under `legacyFollowListCallbackKey` in the
+    /// keyed `followListReceivedCallbacks` dictionary, so it is delivered alongside
+    /// any subscription-keyed callbacks instead of overwriting them. Existing
+    /// callers (e.g. StreamViewModel) that assign this property continue to work,
+    /// while new callers should prefer `addFollowListReceivedCallback(forSubscriptionId:_:)`.
+    var onFollowListReceived: (([String]) -> Void)? {
+        get {
+            followListReceivedCallbacks[Self.legacyFollowListCallbackKey]
+        }
+        set {
+            if let newValue = newValue {
+                followListReceivedCallbacks[Self.legacyFollowListCallbackKey] = newValue
+            } else {
+                followListReceivedCallbacks.removeValue(forKey: Self.legacyFollowListCallbackKey)
+            }
+        }
+    }
 
     /// Called when a user relay list (kind 10002) is received
     /// Each entry contains the relay URL and its read/write permissions per NIP-65
@@ -601,6 +625,20 @@ class NostrSDKClient {
         chatReceivedCallbacks[key] = callback
     }
 
+    /// Add a callback for follow list received events, keyed by subscription ID.
+    /// Using the same `subscriptionId` replaces any existing callback for that subscription.
+    /// This is the preferred API for new callers; it prevents one component from
+    /// overwriting another component's handler (the failure mode that Bug #14 fixed).
+    func addFollowListReceivedCallback(forSubscriptionId subscriptionId: String, _ callback: @escaping ([String]) -> Void) {
+        followListReceivedCallbacks[subscriptionId] = callback
+    }
+
+    /// Backward-compatible overload that stores the callback under a generated unique key.
+    func addFollowListReceivedCallback(_ callback: @escaping ([String]) -> Void) {
+        let key = "unkeyed-follow-list-\(UUID().uuidString)"
+        followListReceivedCallbacks[key] = callback
+    }
+
     /// Add a callback for zap receipt received events, keyed by subscription ID.
     /// Using the same `subscriptionId` replaces any existing callback for that subscription.
     func addZapReceivedCallback(forSubscriptionId subscriptionId: String, _ callback: @escaping (ZapComment) -> Void) {
@@ -614,8 +652,10 @@ class NostrSDKClient {
     }
 
     /// Remove callbacks for a specific subscription ID.
+    /// Removes profile, follow list, chat, AND zap callbacks registered under that key.
     func removeCallback(forSubscriptionId subscriptionId: String) {
         profileReceivedCallbacks.removeValue(forKey: subscriptionId)
+        followListReceivedCallbacks.removeValue(forKey: subscriptionId)
         chatReceivedCallbacks.removeValue(forKey: subscriptionId)
         zapReceivedCallbacks.removeValue(forKey: subscriptionId)
     }
@@ -852,8 +892,14 @@ class NostrSDKClient {
 
         print("📋 NostrSDKClient: Extracted \(follows.count) follows from kind 3 event")
 
+        // Notify all registered follow-list callbacks (keyed + legacy property).
+        // Iterating a copy of the values keeps the dictionary stable if a callback
+        // mutates it during iteration.
         DispatchQueue.main.async { [weak self] in
-            self?.onFollowListReceived?(follows)
+            guard let self = self else { return }
+            for callback in self.followListReceivedCallbacks.values {
+                callback(follows)
+            }
         }
     }
 

--- a/nostrTV/ProfileSettingsView.swift
+++ b/nostrTV/ProfileSettingsView.swift
@@ -246,7 +246,12 @@ struct ProfileSettingsView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color.coveBackground)
         .onAppear {
-            // If profile is not loaded but user is authenticated, fetch it
+            // If profile is not loaded but user is authenticated, fetch it.
+            // With the Bug #14 fix, the primary profile fetch happens
+            // deterministically inside `authenticateWithBunker` (and on session
+            // restore). This call is a harmless refresh for the case where the
+            // profile is still missing — it is non-forcing, so it no-ops when
+            // a fetch is already in flight. It is NOT the primary fetch path.
             if authManager.currentProfile == nil && authManager.isAuthenticated {
                 authManager.fetchUserData()
             }


### PR DESCRIPTION
## Summary

Fixes #14 — Remote signer login fails to load profile until app restart.

### Root Cause

After PR #17, the profile callback in NostrAuthManager.fetchUserData was keyed to 'user-data-auth', but subscribeToUserData created a subscription with a random UUID. The callback and subscription were on different keys — the callback fired for all profile events, but there was no guarantee a subscription for the authenticated user pubkey was active when authenticateWithBunker completed.

Additionally, onFollowListReceived was a single optional closure that could be overwritten by other components.

### Changes (3 files)

**NostrAuthManager.swift**
- fetchUserData now creates the subscription with the SAME ID as the callback (userDataSubscriptionId), using subscribe(with:subscriptionId:purpose:) — guaranteeing the subscription and callback are linked
- Follow list callback now uses keyed addFollowListReceivedCallback(forSubscriptionId:) instead of onFollowListReceived = (prevents overwrite by other components)
- authenticateWithBunker now calls nostrSDKClient.connect() before fetchUserData to ensure relays are connecting
- Added import NostrSDK for Filter type

**NostrSDKClient.swift**
- Added followListReceivedCallbacks dictionary keyed by subscription ID (matching the pattern for profile/chat/zap)
- New addFollowListReceivedCallback(forSubscriptionId:_:) method
- onFollowListReceived is now a computed property backed by the dictionary (backward compatible — existing callers like StreamViewModel still work)
- removeCallback(forSubscriptionId:) now also removes follow list callbacks
- handleFollowListEvent iterates all registered callbacks

**ProfileSettingsView.swift**
- Added comment explaining the onAppear fetchUserData call is a refresh, not the primary fetch path

### Cannot build/test on Linux
Code changes only — please test on macOS/Xcode.