### PR TITLE
fix: stop tearing down the shared relay pool on logout and deinit

### DIFF
--- a/nostrTV/NostrAuthManager.swift
+++ b/nostrTV/NostrAuthManager.swift
@@ -305,8 +305,17 @@ class NostrAuthManager: ObservableObject {
         authMethod = nil
         errorMessage = nil
 
-        // Disconnect client
-        nostrSDKClient.disconnect()
+        // Retire only this manager's own subscription and callbacks.
+        //
+        // Deliberately does NOT call nostrSDKClient.disconnect(): that client is
+        // the shared app-level relay pool, also serving stream discovery, chat and
+        // zaps. Disconnecting it is unrecoverable without an app restart — it stops
+        // the heartbeat (so nothing triggers a reconnect), clears `cancellables`
+        // (and setupEventStream() only runs from init, so events stop being
+        // processed), and empties `activeSubscriptions` (so resubscribe has no
+        // filters to replay). Logging out must not take the whole app offline.
+        nostrSDKClient.closeSubscription(Self.userDataSubscriptionId)
+        nostrSDKClient.removeCallback(forSubscriptionId: Self.userDataSubscriptionId)
     }
 
     // MARK: - Event Signing

--- a/nostrTV/NostrSDKClient.swift
+++ b/nostrTV/NostrSDKClient.swift
@@ -253,7 +253,19 @@ class NostrSDKClient {
         lastMessageTime = Date()
     }
 
-    /// Disconnect from all relays
+    /// Disconnect from all relays.
+    ///
+    /// - Important: This is **terminal and not recoverable** by calling `connect()`
+    ///   again. It stops the heartbeat (nothing will detect silence and reconnect),
+    ///   clears `cancellables` — and `setupEventStream()` only runs from `init`, so
+    ///   incoming events stop being processed permanently — and empties
+    ///   `activeSubscriptions`, leaving `performReconnection()` no filters to replay.
+    ///
+    ///   Because this client is shared app-wide, calling it takes stream discovery,
+    ///   auth, chat and zaps offline until the process restarts. No component that
+    ///   merely *uses* the shared client should call this; scope cleanup to your own
+    ///   subscriptions via `closeSubscription(_:)` and `removeCallback(forSubscriptionId:)`.
+    ///   It currently has no callers, and is kept only for whole-app teardown.
     func disconnect() {
         stopHeartbeat()
         relayPool.disconnect()
@@ -607,11 +619,6 @@ class NostrSDKClient {
         profileReceivedCallbacks[subscriptionId] = callback
     }
 
-    /// Backward-compatible overload that stores the callback under a generated unique key.
-    func addProfileReceivedCallback(_ callback: @escaping (Profile) -> Void) {
-        let key = "unkeyed-profile-\(UUID().uuidString)"
-        profileReceivedCallbacks[key] = callback
-    }
 
     /// Add a callback for chat message received events, keyed by subscription ID.
     /// Using the same `subscriptionId` replaces any existing callback for that subscription.
@@ -619,11 +626,6 @@ class NostrSDKClient {
         chatReceivedCallbacks[subscriptionId] = callback
     }
 
-    /// Backward-compatible overload that stores the callback under a generated unique key.
-    func addChatReceivedCallback(_ callback: @escaping (ZapComment) -> Void) {
-        let key = "unkeyed-chat-\(UUID().uuidString)"
-        chatReceivedCallbacks[key] = callback
-    }
 
     /// Add a callback for follow list received events, keyed by subscription ID.
     /// Using the same `subscriptionId` replaces any existing callback for that subscription.
@@ -633,11 +635,6 @@ class NostrSDKClient {
         followListReceivedCallbacks[subscriptionId] = callback
     }
 
-    /// Backward-compatible overload that stores the callback under a generated unique key.
-    func addFollowListReceivedCallback(_ callback: @escaping ([String]) -> Void) {
-        let key = "unkeyed-follow-list-\(UUID().uuidString)"
-        followListReceivedCallbacks[key] = callback
-    }
 
     /// Add a callback for zap receipt received events, keyed by subscription ID.
     /// Using the same `subscriptionId` replaces any existing callback for that subscription.
@@ -645,11 +642,6 @@ class NostrSDKClient {
         zapReceivedCallbacks[subscriptionId] = callback
     }
 
-    /// Backward-compatible overload that stores the callback under a generated unique key.
-    func addZapReceivedCallback(_ callback: @escaping (ZapComment) -> Void) {
-        let key = "unkeyed-zap-\(UUID().uuidString)"
-        zapReceivedCallbacks[key] = callback
-    }
 
     /// Remove callbacks for a specific subscription ID.
     /// Removes profile, follow list, chat, AND zap callbacks registered under that key.

--- a/nostrTV/StreamViewModel.swift
+++ b/nostrTV/StreamViewModel.swift
@@ -328,7 +328,11 @@ class StreamViewModel: ObservableObject {
         if let subId = deletionsSubscriptionId {
             sdkClient.closeSubscription(subId)
         }
-        sdkClient.disconnect()
+        // Deliberately does NOT call sdkClient.disconnect(): the client is the
+        // shared app-level relay pool and outlives this view model. Disconnecting
+        // it here would permanently stop events for auth, chat and zaps too (see
+        // the note in NostrAuthManager.logout). Closing our own subscriptions
+        // above is the correct scope of cleanup.
     }
 
     // MARK: - Stream Management


### PR DESCRIPTION
## Summary

Removes the last two regressions from the single-shared-client refactor (#16). Both `NostrAuthManager.logout()` and `StreamViewModel.deinit` called `disconnect()` on the shared app-level `NostrSDKClient`, which neither of them owns.

## Why this matters

`disconnect()` is terminal, not a pause. It:

- `stopHeartbeat()` — nothing is left to detect silence and trigger a reconnect
- `cancellables.removeAll()` — cancels the event stream, and `setupEventStream()` runs **only from `init`**, so a later `connect()` cannot restore it
- `activeSubscriptions.removeAll()` — discards the stored filters that `performReconnection()` needs to replay

Net effect: logging out took stream discovery, chat and zaps offline until the app was restarted, and defeated the resubscribe machinery added in #17.

## Changes

**`3817d7d`** — each site now scopes cleanup to what it owns:
- `logout()` closes and unregisters its own `user-data-auth` subscription
- `StreamViewModel.deinit` closes its own subscriptions only

**`4874c2c`** — hardening:
- Documented `disconnect()` as terminal and unrecoverable (it now has no callers)
- Removed the four unkeyed `add*Callback` overloads, which registered under a random `unkeyed-<UUID>` key that no caller could ever pass to `removeCallback(forSubscriptionId:)`. All call sites already used the keyed variants, so these were dead code.

## Testing

- Builds clean for tvOS simulator
- 25-second run matches the `dev` baseline: 46 stream events, 11 live + 7 ended, one `RelayPool`, zero errors

**Not covered:** the logout path itself was not exercised at runtime — that requires a signed-in account. Verified by code reading. A real test should sign in, log out, and confirm Curated keeps updating afterward; on current `dev` it stops dead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)