### PR TITLE
Fix stuck stream list, and restore live chat and zaps

### DIFF
--- a/nostrTV/ContentView.swift
+++ b/nostrTV/ContentView.swift
@@ -452,8 +452,21 @@ struct ContentView: View {
 
     init(nostrSDKClient: NostrSDKClient) {
         self.nostrSDKClient = nostrSDKClient
-        let vm = StreamViewModel(nostrSDKClient: nostrSDKClient)
-        _viewModel = StateObject(wrappedValue: vm)
+        // NOTE: the StreamViewModel must be constructed *inside* the autoclosure.
+        //
+        // StateObject.init(wrappedValue:) takes an @autoclosure precisely so the
+        // object is built only once, on first render. Assigning it to a local
+        // first (`let vm = StreamViewModel(...)`) defeats that: SwiftUI
+        // re-initializes View structs freely, so a new view model was built on
+        // every init while StateObject kept only the first.
+        //
+        // That mattered because each extra instance ran setupCallbacks(), which
+        // assigns the single-closure `sdkClient.onStreamReceived` on the *shared*
+        // client. Last writer won — and the last writer was an instance SwiftUI
+        // immediately discarded, so its [weak self] went nil and every stream
+        // event was dropped. The retained view model never saw a stream, leaving
+        // `isInitialLoad` true and the Curated tab stuck on the loading spinner.
+        _viewModel = StateObject(wrappedValue: StreamViewModel(nostrSDKClient: nostrSDKClient))
     }
 
     var body: some View {

--- a/nostrTV/NostrSDKClient.swift
+++ b/nostrTV/NostrSDKClient.swift
@@ -253,6 +253,49 @@ class NostrSDKClient {
         lastMessageTime = Date()
     }
 
+    /// Add relays to the shared pool, connecting any that are new.
+    ///
+    /// Used for NIP-53 stream relays: a stream's chat (kind 1311) and zap receipts
+    /// (kind 9735) are typically published only to the relays named in the event's
+    /// "relays" tag, which are usually not in our default set. Subscribing without
+    /// them yields a well-formed request that simply never matches anything.
+    ///
+    /// `RelayPool.add` de-duplicates by URL and connects automatically, so calling
+    /// this repeatedly with the same URLs is safe.
+    ///
+    /// A newly added relay is not connected yet, and `Relay.subscribe` throws
+    /// `.notConnected` (an error `RelayPool` swallows), so a subscription created
+    /// right now would silently skip it. After a short delay to let the socket come
+    /// up, all active subscriptions are re-emitted with their original IDs — which
+    /// is idempotent for relays that already have them.
+    /// - Parameter urls: Relay URLs to ensure are present in the pool.
+    func addRelays(_ urls: [String]) {
+        let existingURLs = Set(relayPool.relays.map { $0.url.absoluteString })
+        var addedAny = false
+
+        for urlString in urls {
+            guard let url = URL(string: urlString),
+                  !existingURLs.contains(url.absoluteString) else { continue }
+
+            do {
+                let relay = try Relay(url: url)
+                relayPool.add(relay: relay)
+                addedAny = true
+                print("🔌 NostrSDKClient: Added stream relay \(url.absoluteString)")
+            } catch {
+                print("⚠️ NostrSDKClient: Skipping invalid stream relay \(urlString): \(error.localizedDescription)")
+            }
+        }
+
+        guard addedAny else { return }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
+            guard let self = self else { return }
+            print("🔄 NostrSDKClient: Re-emitting subscriptions to newly added relays")
+            self.resubscribeAll()
+        }
+    }
+
     /// Disconnect from all relays.
     ///
     /// - Important: This is **terminal and not recoverable** by calling `connect()`
@@ -1121,6 +1164,15 @@ class NostrSDKClient {
         let gTags = event.tags.filter { $0.name == "g" }.compactMap { $0.value }
         let allTags = hashtags + gTags
 
+        // Extract the NIP-53 "relays" tag: a single tag carrying many values,
+        // e.g. ["relays", "wss://relay.one", "wss://relay.two"], so the first
+        // value and otherParameters are all relay URLs. This is where the
+        // stream's chat and zap events actually live.
+        let streamRelays: [String] = event.tags
+            .filter { $0.name == "relays" }
+            .flatMap { [$0.value] + $0.otherParameters }
+            .filter { $0.hasPrefix("wss://") || $0.hasPrefix("ws://") }
+
         // Extract recording URL and starts timestamp
         let recording = tagValue("recording")
         let startsAt: Date? = {
@@ -1171,7 +1223,8 @@ class NostrSDKClient {
             createdAt: createdAt,
             viewerCount: viewerCount,
             recording: recording,
-            startsAt: startsAt
+            startsAt: startsAt,
+            relays: streamRelays
         )
 
         // Notify callback

--- a/nostrTV/NostrSDKClient.swift
+++ b/nostrTV/NostrSDKClient.swift
@@ -140,6 +140,10 @@ class NostrSDKClient {
     /// Non-fatal initialization error, if the client was created as an error fallback.
     private(set) var initError: Error?
 
+    /// Maximum subscription ID length permitted by NIP-01.
+    /// "`<subscription_id>` is an arbitrary, non-empty string of max length 64 chars."
+    static let maxSubscriptionIdLength = 64
+
     // MARK: - Callbacks (matching NostrClient interface)
 
     /// Called when a live stream event (kind 30311) is received
@@ -507,6 +511,16 @@ class NostrSDKClient {
     /// Subscribe with an explicit subscription ID so reconnection can restore the exact same subscription.
     @discardableResult
     func subscribe(with filter: Filter, subscriptionId: String, purpose: String = "custom") -> String {
+        // NIP-01 caps subscription IDs at 64 characters. Relays reject longer ones,
+        // and they do it silently from our side: the REQ simply never takes effect
+        // and no events ever arrive for that subscription. Fail loudly instead.
+        if subscriptionId.count > Self.maxSubscriptionIdLength {
+            assertionFailure("Subscription ID for '\(purpose)' is \(subscriptionId.count) chars, over the NIP-01 limit of \(Self.maxSubscriptionIdLength)")
+            print("❌ NostrSDKClient: Subscription ID for '\(purpose)' is \(subscriptionId.count) chars, "
+                  + "over the NIP-01 limit of \(Self.maxSubscriptionIdLength). Relays will reject this REQ "
+                  + "and no events will arrive: \(subscriptionId)")
+        }
+
         let actualId = relayPool.subscribe(with: filter, subscriptionId: subscriptionId)
         subscriptionsLock.lock()
         activeSubscriptions[actualId] = StoredSubscription(id: actualId, filter: filter, purpose: purpose)

--- a/nostrTV/Stream.swift
+++ b/nostrTV/Stream.swift
@@ -34,6 +34,14 @@ struct Stream: Identifiable, Codable, Equatable {
     let recording: String?  // Recording URL from "recording" tag
     let startsAt: Date?     // From "starts" tag (unix timestamp)
 
+    /// Relays this stream's chat lives on, from the NIP-53 "relays" tag.
+    ///
+    /// Kind 30311 announcements propagate widely, but the kind 1311 chat messages
+    /// and kind 9735 zap receipts for a stream are usually published only to these
+    /// relays. Without connecting to them the chat subscription is well-formed but
+    /// returns nothing. Defaults to empty for streams that omit the tag.
+    var relays: [String] = []
+
     var id: String { streamID }
 
     var isLive: Bool {

--- a/nostrTV/StreamActivityManager.swift
+++ b/nostrTV/StreamActivityManager.swift
@@ -68,11 +68,18 @@ class StreamActivityManager: ObservableObject {
         }
 
         // Generate a unique subscription ID per listening session.
-        // Using a UUID suffix ensures that stopListening on an old StreamActivityManager
+        // The UUID suffix ensures that stopListening on an old StreamActivityManager
         // can never accidentally remove callbacks for a new one's subscription, even if
         // SwiftUI's @StateObject lifecycle causes old/new managers to overlap.
+        //
+        // IMPORTANT: do not put the a-tag in this ID. NIP-01 caps subscription IDs at
+        // 64 characters, and an a-tag is 71 chars before its d-tag even starts
+        // ("30311:" + 64-char pubkey + ":"). Including it produced IDs of 90+ chars,
+        // which relays reject — so the REQ never took effect and neither chat nor zaps
+        // ever arrived. The UUID alone gives us the uniqueness we actually need.
         let uuidSuffix = String(UUID().uuidString.prefix(8))
-        let uniqueSubscriptionId = "chat-zaps-\(aTag)-\(uuidSuffix)"
+        let uniqueSubscriptionId = "chat-zaps-\(uuidSuffix)"
+        assert(uniqueSubscriptionId.count <= 64, "Subscription ID exceeds the NIP-01 64-character limit")
 
         // Clear existing data
         chatMessages = []

--- a/nostrTV/StreamActivityManager.swift
+++ b/nostrTV/StreamActivityManager.swift
@@ -57,6 +57,16 @@ class StreamActivityManager: ObservableObject {
         self.currentStreamATag = ATag.construct(pubkey: authorPubkey, dTag: stream.streamID)
         let aTag = currentStreamATag!
 
+        // Join the stream's own relays before subscribing. Chat (1311) and zap
+        // receipts (9735) are usually published only there, not to our default
+        // relay set, so without this the subscription below matches nothing.
+        if !stream.relays.isEmpty {
+            print("📺 StreamActivityManager: Stream lists \(stream.relays.count) relay(s): \(stream.relays.joined(separator: ", "))")
+            client.addRelays(stream.relays)
+        } else {
+            print("📺 StreamActivityManager: Stream lists no relays; using the default pool only")
+        }
+
         // Generate a unique subscription ID per listening session.
         // Using a UUID suffix ensures that stopListening on an old StreamActivityManager
         // can never accidentally remove callbacks for a new one's subscription, even if

--- a/nostrTVTests/SubscriptionIDTests.swift
+++ b/nostrTVTests/SubscriptionIDTests.swift
@@ -1,0 +1,57 @@
+//
+//  SubscriptionIDTests.swift
+//  nostrTVTests
+//
+//  Guards the NIP-01 subscription ID length limit.
+//
+//  NIP-01: "<subscription_id> is an arbitrary, non-empty string of max length
+//  64 chars." Relays reject longer IDs, and they do so invisibly from the
+//  client's perspective — the REQ never takes effect and no events arrive.
+//
+//  This regressed once: the chat/zap subscription ID embedded the stream's
+//  a-tag, which is 71 characters before its d-tag even starts, so every chat
+//  subscription was silently dropped and neither comments nor zaps appeared.
+//
+
+import Testing
+import Foundation
+@testable import nostrTV
+
+struct SubscriptionIDTests {
+
+    private static let pubkey = "266815e0c9210dfa324c6cba3573b14bee49da4209a9456f9484e5106cd408a5"
+
+    @Test func nipLimitIs64() {
+        #expect(NostrSDKClient.maxSubscriptionIdLength == 64)
+    }
+
+    /// The shape StreamActivityManager builds: a short prefix plus a UUID fragment.
+    @Test func chatSubscriptionIDFitsWithinTheLimit() {
+        let id = "chat-zaps-\(UUID().uuidString.prefix(8))"
+        #expect(id.count <= NostrSDKClient.maxSubscriptionIdLength)
+    }
+
+    /// Even a full UUID leaves plenty of headroom, so uniqueness never costs us the limit.
+    @Test func fullUUIDSuffixWouldAlsoFit() {
+        let id = "chat-zaps-\(UUID().uuidString)"
+        #expect(id.count <= NostrSDKClient.maxSubscriptionIdLength)
+    }
+
+    /// Documents precisely why embedding an a-tag is not viable: an a-tag is
+    /// 71 characters before the d-tag contributes anything, so any ID containing
+    /// one breaks the limit no matter how short the rest is.
+    @Test func aTagCannotFitInsideASubscriptionID() {
+        let aTag = ATag.construct(pubkey: Self.pubkey, dTag: "")
+        #expect(aTag.count == 71)
+        #expect(aTag.count > NostrSDKClient.maxSubscriptionIdLength)
+
+        let offendingID = "chat-zaps-\(ATag.construct(pubkey: Self.pubkey, dTag: "demo-stream"))-abcd1234"
+        #expect(offendingID.count > NostrSDKClient.maxSubscriptionIdLength)
+    }
+
+    /// The other subscription IDs used in the app.
+    @Test func otherSubscriptionIDsFit() {
+        #expect("user-data-auth".count <= NostrSDKClient.maxSubscriptionIdLength)
+        #expect("bunker-\(UUID().uuidString.prefix(8))".count <= NostrSDKClient.maxSubscriptionIdLength)
+    }
+}


### PR DESCRIPTION
## Summary

Three fixes: the Curated tab hanging on the loading spinner, and comments/zaps never appearing in the player. Verified working by @tkhumush.

## 1. Curated tab stuck on "Preparing your spot by the fire…" (`560b378`)

`ContentView.init` built the view model into a local before handing it to `StateObject`:

```swift
let vm = StreamViewModel(nostrSDKClient: nostrSDKClient)
_viewModel = StateObject(wrappedValue: vm)
```

`StateObject.init(wrappedValue:)` takes an `@autoclosure` so the object is constructed only once. Assigning to a local first defeats that — SwiftUI re-initializes View structs freely, so a fresh view model was built on every init while `StateObject` retained only the first.

Each extra instance ran `setupCallbacks()`, which assigns the single-closure `sdkClient.onStreamReceived` on the **shared** client. Last writer won, and that writer was an instance SwiftUI had already discarded: its `[weak self]` was nil, so every stream event was dropped. `isInitialLoad` stayed `true` forever.

Only reproduced when `ContentView` initialized more than once, which is why it hit signed-in users — restoring a session publishes from the app-level `authManager`, re-evaluating the `WindowGroup` body. Latent since #16; before the shared client, overwriting the callback was harmless.

## 2. Chat subscription ID exceeded the NIP-01 limit (`deb8bd1`) — the cause of missing comments and zaps

NIP-01: *"`<subscription_id>` is an arbitrary, non-empty string of max length 64 chars."*

The chat/zap subscription embedded the stream's a-tag in its ID:

```swift
let uniqueSubscriptionId = "chat-zaps-\(aTag)-\(uuidSuffix)"
```

An a-tag is **71 characters before its d-tag contributes anything** (`"30311:"` + 64-char pubkey + `":"`), so every ID was 90+ chars — over the limit for every stream, without exception. Relays reject over-long IDs invisibly: the REQ never takes effect and no events arrive.

That is why chat and zaps failed **together** while streams kept working — they share this one subscription; stream subscriptions use plain 36-char UUIDs.

The a-tag was never needed in the ID; its purpose was per-session uniqueness, which the UUID suffix already provides. The a-tag stays in the filter as `#a`.

Verified against NIP-53 that the rest was correct: the a-tag format is `30311:<event author pubkey>:<d-identifier>`, matching what we construct and filter on.

**Guard added:** `subscribe(with:subscriptionId:purpose:)` now asserts and logs loudly when an ID exceeds 64 chars, instead of letting the subscription vanish silently.

## 3. Join the stream's own NIP-53 relays (`ce2dcb0`)

Kind 1311/9735 events are typically published only to the relays in the event's `relays` tag, which the app never read. `Stream` gains a `relays` field and `StreamActivityManager` joins them before subscribing.

Full disclosure: this was a hypothesis that did **not** fix the bug — #2 did. It is still correct per NIP-53 and makes chat more robust for streams on niche relays, at the cost of the shared pool growing as more streams are watched. Kept deliberately.

A newly added relay isn't connected yet and `Relay.subscribe` throws `.notConnected` (swallowed by `RelayPool`), so `addRelays` re-emits active subscriptions after 2s with their original IDs.

## Testing

- Builds clean; **19 tests pass**
- 5 new regression tests pinning the NIP-01 limit and documenting why an a-tag can never fit inside a subscription ID
- Manually verified: stream list loads, comments and zaps display

🤖 Generated with [Claude Code](https://claude.com/claude-code)