### PR TITLE
Fix the Following tab: host resolution, follow-list subscriptions, and identity routing

### DIFF
--- a/nostrTV/ContentView.swift
+++ b/nostrTV/ContentView.swift
@@ -35,6 +35,45 @@ struct CuratedLoadingView: View {
 }
 
 /// Empty state view for Following tab when user is not logged in
+/// Shown on the Following tab when the user is logged in but the list is empty.
+///
+/// An empty list previously rendered as a completely blank page, which made three
+/// very different situations indistinguishable — the follow list never loading, the
+/// follow list loading fine with nobody currently streaming, and the filter being
+/// broken. This states which one it is.
+struct FollowingNoStreamsView: View {
+    /// Number of pubkeys in the user's kind 3 follow list.
+    let followCount: Int
+
+    private var isFollowListMissing: Bool { followCount == 0 }
+
+    var body: some View {
+        VStack(spacing: 30) {
+            Spacer()
+
+            Image(systemName: isFollowListMissing ? "person.crop.circle.badge.questionmark" : "moon.zzz.fill")
+                .font(.system(size: 100))
+                .foregroundColor(.coveAccent.opacity(0.6))
+
+            Text(isFollowListMissing ? "Your follow list hasn't loaded" : "Nobody you follow is live")
+                .font(.coveSubheading)
+                .foregroundColor(.white)
+
+            Text(isFollowListMissing
+                 ? "We couldn't read your follow list from the relays. Check your connection, or open Profile to retry."
+                 : "You're following \(followCount) \(followCount == 1 ? "person" : "people"). None of them are streaming right now — check back later.")
+                .font(.coveBody)
+                .foregroundColor(.coveSecondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 80)
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.coveBackground)
+    }
+}
+
 struct FollowingEmptyStateView: View {
     let onLoginTap: () -> Void
 
@@ -519,6 +558,9 @@ struct ContentView: View {
                 // Following tab
                 NavigationView {
                     if authManager.isAuthenticated {
+                        if viewModel.categorizedStreams.isEmpty && viewModel.featuredStream == nil {
+                            FollowingNoStreamsView(followCount: viewModel.followListCount)
+                        } else {
                         StreamListView(
                             viewModel: viewModel,
                             categorizedStreams: viewModel.categorizedStreams,
@@ -551,6 +593,7 @@ struct ContentView: View {
 
                             self.selectedStream = streamWithProfile
                             self.showPlayer = true
+                        }
                         }
                     } else {
                         FollowingEmptyStateView(onLoginTap: {

--- a/nostrTV/NostrAuthManager.swift
+++ b/nostrTV/NostrAuthManager.swift
@@ -60,6 +60,12 @@ class NostrAuthManager: ObservableObject {
             loadCachedProfile()
             isLoadingProfile = false
 
+            // Refresh profile and follow list from the relays. Restoring a session
+            // only rehydrates the cache; without this nothing ever subscribes for the
+            // user's kind 3, so an empty or stale cache left the Following tab blank
+            // until the user logged in again or opened Profile settings.
+            refreshUserDataAfterRestore()
+
             // Reconnect bunker client in background
             Task { @MainActor in
                 await restoreBunkerSession(bunkerSession)
@@ -72,6 +78,22 @@ class NostrAuthManager: ObservableObject {
             isAuthenticated = true
             loadCachedProfile()
             isLoadingProfile = false
+            refreshUserDataAfterRestore()
+        }
+    }
+
+    /// Fetch the user's profile and follow list after restoring a saved session.
+    ///
+    /// Mirrors the login-time path: connect the shared pool first so the subscription
+    /// is not issued against relays that have not begun connecting (Bug #14), then
+    /// fetch. Runs on the next main-loop turn because `init` has not finished yet and
+    /// `fetchUserData` reads `currentUser`.
+    private func refreshUserDataAfterRestore() {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            print("🔄 NostrAuthManager: Refreshing profile and follow list after session restore")
+            self.nostrSDKClient.connect()
+            self.fetchUserData(force: true)
         }
     }
 
@@ -148,10 +170,17 @@ class NostrAuthManager: ObservableObject {
         // is delivered when this subscription's kind-3 events arrive. Using the
         // keyed API prevents StreamViewModel (or any other component) from
         // overwriting this handler via the legacy `onFollowListReceived` property.
-        nostrSDKClient.addFollowListReceivedCallback(forSubscriptionId: Self.userDataSubscriptionId) { [weak self] follows in
+        nostrSDKClient.addFollowListReceivedCallback(forSubscriptionId: Self.userDataSubscriptionId) { [weak self] authorPubkey, follows in
+            guard let self = self else { return }
+            // Kind 3 events for other pubkeys — notably the admin's, fetched at startup
+            // for the Curated tab — arrive on this same dispatch. Adopting one of those
+            // would silently replace the user's follow list, and cache it.
+            guard authorPubkey.caseInsensitiveCompare(user.hexPubkey) == .orderedSame else {
+                return
+            }
             DispatchQueue.main.async {
-                self?.followList = follows
-                self?.saveFollowListToCache(follows)
+                self.followList = follows
+                self.saveFollowListToCache(follows)
             }
         }
 

--- a/nostrTV/NostrAuthManager.swift
+++ b/nostrTV/NostrAuthManager.swift
@@ -102,7 +102,19 @@ class NostrAuthManager: ObservableObject {
 
         do {
             let decoder = JSONDecoder()
-            currentProfile = try decoder.decode(Profile.self, from: profileData)
+            let cached = try decoder.decode(Profile.self, from: profileData)
+
+            // Only accept a cached profile that actually belongs to the signed-in
+            // account. A build that mis-assigned incoming profiles could have
+            // persisted someone else's here, and a stale entry would otherwise
+            // survive indefinitely and keep showing the wrong identity.
+            if let user = currentUser,
+               cached.pubkey.caseInsensitiveCompare(user.hexPubkey) != .orderedSame {
+                print("⚠️ NostrAuthManager: Cached profile belongs to \(cached.pubkey.prefix(8))… but the signed-in user is \(user.hexPubkey.prefix(8))…; discarding it")
+                UserDefaults.standard.removeObject(forKey: "nostrUserProfile")
+            } else {
+                currentProfile = cached
+            }
         } catch {
             print("\u{26A0}\u{FE0F} NostrAuthManager: Failed to decode cached profile, clearing it: \(error.localizedDescription)")
             UserDefaults.standard.removeObject(forKey: "nostrUserProfile")
@@ -159,10 +171,18 @@ class NostrAuthManager: ObservableObject {
 
         // Setup callback for profile, keyed by subscription ID (replaces, not appends)
         nostrSDKClient.addProfileReceivedCallback(forSubscriptionId: Self.userDataSubscriptionId) { [weak self] profile in
+            guard let self = self else { return }
+            // Every kind 0 event is delivered to every registered profile callback, and
+            // the app subscribes to profiles for the whole follow list. Without this
+            // check the logged-in identity was reassigned to each arriving profile in
+            // turn — the account appeared to cycle through the people it follows.
+            guard profile.pubkey.caseInsensitiveCompare(user.hexPubkey) == .orderedSame else {
+                return
+            }
             DispatchQueue.main.async {
-                self?.currentProfile = profile
-                self?.isLoadingProfile = false
-                self?.saveProfileToCache(profile)
+                self.currentProfile = profile
+                self.isLoadingProfile = false
+                self.saveProfileToCache(profile)
             }
         }
 

--- a/nostrTV/NostrSDKClient.swift
+++ b/nostrTV/NostrSDKClient.swift
@@ -646,8 +646,30 @@ class NostrSDKClient {
             print("❌ NostrSDKClient: Failed to create author-filtered streams filter")
             return nil
         }
-        let subId = subscribe(with: filter, purpose: "streams-filtered")
+        let subId = subscribe(with: filter, purpose: "streams-by-author")
         print("✅ NostrSDKClient: Subscribed to streams from \(authors.count) authors (limit: \(limit)): \(subId.prefix(8))...")
+        return subId
+    }
+
+    /// Subscribe to live streams where any of the given pubkeys is a tagged participant.
+    ///
+    /// The `authors` filter only matches the event signer. A stream published on
+    /// someone's behalf names the host in a `p` tag instead, so following the host
+    /// alone would not match an author-filtered subscription. This `#p` filter is the
+    /// relay-side counterpart to the host-or-author match the Following tab applies
+    /// locally.
+    /// - Parameters:
+    ///   - participants: Pubkeys to match against the event's `p` tags.
+    ///   - limit: Maximum stored events to return.
+    func subscribeToStreams(participants: [String], limit: Int = 50) -> String? {
+        guard !participants.isEmpty else { return nil }
+
+        guard let filter = Filter(kinds: [30311], tags: ["p": participants], limit: limit) else {
+            print("❌ NostrSDKClient: Failed to create participant-filtered streams filter")
+            return nil
+        }
+        let subId = subscribe(with: filter, purpose: "streams-by-participant")
+        print("✅ NostrSDKClient: Subscribed to streams tagging \(participants.count) participants (limit: \(limit)): \(subId.prefix(8))...")
         return subId
     }
 

--- a/nostrTV/NostrSDKClient.swift
+++ b/nostrTV/NostrSDKClient.swift
@@ -144,6 +144,39 @@ class NostrSDKClient {
     /// "`<subscription_id>` is an arbitrary, non-empty string of max length 64 chars."
     static let maxSubscriptionIdLength = 64
 
+    /// Resolve the host of a NIP-53 live event (kind 30311) from its tags.
+    ///
+    /// A `p` tag is a participant entry, not necessarily the host:
+    ///
+    ///     ["p", "<pubkey>", "<relay-url>", "<role>", "<proof>"]
+    ///
+    /// where the role is a displayable marker such as `Host`, `Speaker` or
+    /// `Participant`. Simply taking the first `p` tag picks a guest on any
+    /// multi-participant stream, which shows the wrong profile and hides the stream
+    /// from the Following tab, since that filter matches on the host pubkey.
+    ///
+    /// The role's position varies in practice — the relay URL is frequently empty or
+    /// omitted entirely — so the marker is matched anywhere in the tag's parameters
+    /// rather than at a fixed index.
+    ///
+    /// - Parameters:
+    ///   - tags: The event's tags.
+    ///   - eventAuthorPubkey: The event signer, used when no participant is listed.
+    /// - Returns: The host pubkey, the first participant, or the event author.
+    static func hostPubkey(fromTags tags: [Tag], eventAuthorPubkey: String) -> String {
+        let participantTags = tags.filter { $0.name == "p" }
+
+        if let host = participantTags.first(where: { tag in
+            tag.otherParameters.contains { $0.caseInsensitiveCompare("host") == .orderedSame }
+        }) {
+            return host.value
+        }
+
+        // No explicit Host marker: fall back to the first participant, then to the
+        // event signer (streams published by the host itself carry no p tag at all).
+        return participantTags.first?.value ?? eventAuthorPubkey
+    }
+
     // MARK: - Callbacks (matching NostrClient interface)
 
     /// Called when a live stream event (kind 30311) is received
@@ -1159,9 +1192,20 @@ class NostrSDKClient {
         let imageURL = tagValue("image")
 
         // IMPORTANT: We need BOTH pubkeys for different purposes:
-        // 1. Host pubkey (p-tag): Used for profile display
+        // 1. Host pubkey (p-tag): Used for profile display and Following-tab filtering
         // 2. Event author pubkey (event.pubkey): Used for a-tag coordinate in chat subscriptions
-        let hostPubkey = tagValue("p") ?? event.pubkey  // Prefer p-tag, fallback to event author
+        //
+        // Per NIP-53 a `p` tag is a participant entry, not necessarily the host:
+        //   ["p", "<pubkey>", "<relay-url>", "<role>", "<proof>"]
+        // with role being a displayable marker such as Host, Speaker or Participant.
+        // Taking the first `p` tag therefore picked a guest on any multi-participant
+        // stream, which showed the wrong profile and — because Following matches on
+        // this pubkey — hid streams whose host the user actually follows.
+        //
+        // Prefer the participant explicitly marked as the host. The role's position
+        // varies (the relay URL is often empty or omitted), so match it anywhere in
+        // the tag's parameters rather than at a fixed index.
+        let hostPubkey = Self.hostPubkey(fromTags: event.tags, eventAuthorPubkey: event.pubkey)
         let eventAuthorPubkey = event.pubkey  // Always the event signer
 
         // Extract viewer count

--- a/nostrTV/NostrSDKClient.swift
+++ b/nostrTV/NostrSDKClient.swift
@@ -187,7 +187,11 @@ class NostrSDKClient {
 
     /// Called when a follow list event (kind 3) is received, keyed by subscription ID.
     /// Using the same `subscriptionId` replaces any existing callback for that subscription.
-    private var followListReceivedCallbacks: [String: ([String]) -> Void] = [:]
+    /// Receives (author pubkey, follows). The author is essential: kind 3 events for
+    /// several different pubkeys flow through this one dispatch (the admin's list for
+    /// the Curated tab and the logged-in user's for Following), and a callback that
+    /// cannot tell them apart will happily adopt someone else's follow list.
+    private var followListReceivedCallbacks: [String: (String, [String]) -> Void] = [:]
 
     /// Special key used to back the backward-compatible `onFollowListReceived` property
     /// so it does not collide with subscription-keyed callbacks.
@@ -199,7 +203,7 @@ class NostrSDKClient {
     /// any subscription-keyed callbacks instead of overwriting them. Existing
     /// callers (e.g. StreamViewModel) that assign this property continue to work,
     /// while new callers should prefer `addFollowListReceivedCallback(forSubscriptionId:_:)`.
-    var onFollowListReceived: (([String]) -> Void)? {
+    var onFollowListReceived: ((String, [String]) -> Void)? {
         get {
             followListReceivedCallbacks[Self.legacyFollowListCallbackKey]
         }
@@ -743,7 +747,7 @@ class NostrSDKClient {
     /// Using the same `subscriptionId` replaces any existing callback for that subscription.
     /// This is the preferred API for new callers; it prevents one component from
     /// overwriting another component's handler (the failure mode that Bug #14 fixed).
-    func addFollowListReceivedCallback(forSubscriptionId subscriptionId: String, _ callback: @escaping ([String]) -> Void) {
+    func addFollowListReceivedCallback(forSubscriptionId subscriptionId: String, _ callback: @escaping (String, [String]) -> Void) {
         followListReceivedCallbacks[subscriptionId] = callback
     }
 
@@ -1002,7 +1006,7 @@ class NostrSDKClient {
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
             for callback in self.followListReceivedCallbacks.values {
-                callback(follows)
+                callback(event.pubkey, follows)
             }
         }
     }

--- a/nostrTV/StreamViewModel.swift
+++ b/nostrTV/StreamViewModel.swift
@@ -177,10 +177,16 @@ class StreamViewModel: ObservableObject {
             }
         }
 
-        // Handle follow list received (for admin follow list fetch)
-        sdkClient.onFollowListReceived = { [weak self] follows in
+        // Handle follow list received (for admin follow list fetch).
+        // Kind 3 events for other pubkeys — notably the logged-in user's, fetched by
+        // NostrAuthManager — arrive on this same callback, so accept only the admin's.
+        sdkClient.onFollowListReceived = { [weak self] authorPubkey, follows in
+            guard let self = self else { return }
+            guard authorPubkey.caseInsensitiveCompare(self.adminPubkey) == .orderedSame else {
+                return
+            }
             DispatchQueue.main.async {
-                self?.handleAdminFollowListReceived(follows)
+                self.handleAdminFollowListReceived(follows)
             }
         }
     }

--- a/nostrTV/StreamViewModel.swift
+++ b/nostrTV/StreamViewModel.swift
@@ -439,12 +439,22 @@ class StreamViewModel: ObservableObject {
         }
         self.allCategorizedStreams = categorizeStreams(discoverStreams)
 
-        // Following: filter by user follow list
+        // Following: filter by user follow list.
+        //
+        // Match either the host (p-tag participant marked Host) or the event author.
+        // Streams published by the host directly carry no p tag, so the host identity
+        // lives in eventAuthorPubkey; streams published on someone's behalf carry both.
+        // Checking only one field silently hid followed streams of the other shape.
         let followingStreams: [Stream]
         if !followList.isEmpty {
             followingStreams = cleanBase.filter { stream in
-                guard let pubkey = stream.pubkey else { return false }
-                return followList.contains(pubkey)
+                if let hostPubkey = stream.pubkey, followList.contains(hostPubkey) {
+                    return true
+                }
+                if let authorPubkey = stream.eventAuthorPubkey, followList.contains(authorPubkey) {
+                    return true
+                }
+                return false
             }
         } else {
             followingStreams = []

--- a/nostrTV/StreamViewModel.swift
+++ b/nostrTV/StreamViewModel.swift
@@ -26,6 +26,21 @@ class StreamViewModel: ObservableObject {
     private var streamsSubscriptionId: String?  // kind 30311 - unfiltered, pipeline handles filtering
     private var deletionsSubscriptionId: String? // kind 5 - stream deletion events
 
+    /// kind 30311 subscriptions scoped to the user's follow list (by author and by p-tag).
+    ///
+    /// The unfiltered subscription above asks for the most recent streams globally, so a
+    /// followed stream only appears if it happens to land in that window. These ask the
+    /// relays directly for streams belonging to people the user follows, so the Following
+    /// tab does not compete with global volume.
+    private var followingStreamsSubscriptionIds: [String] = []
+
+    /// Pubkeys per follow-list subscription.
+    ///
+    /// Follow lists routinely run to hundreds or thousands of entries, and relays impose
+    /// their own limits on filter size — rejecting an over-large REQ silently, exactly
+    /// like the NIP-01 subscription ID limit did. Chunking keeps each filter modest.
+    private let followFilterChunkSize = 200
+
     // Stream collection size limit to prevent unbounded memory growth
     private let maxStreamCount = 200
 
@@ -227,6 +242,40 @@ class StreamViewModel: ObservableObject {
     }
 
     /// Create profiles subscription (kind 0) filtered by author list
+    /// Subscribe to kind 30311 events belonging to the user's follow list.
+    ///
+    /// Two filters per chunk, mirroring the host-or-author match the Following tab
+    /// applies locally: `authors` catches streams a followed user published, and `#p`
+    /// catches streams that tag a followed user as host or participant but were
+    /// published by someone else.
+    private func createFollowingStreamsSubscriptions() {
+        // Close any previous follow-list subscriptions first
+        for subId in followingStreamsSubscriptionIds {
+            print("📪 Closing following-streams subscription: \(subId.prefix(8))...")
+            sdkClient.closeSubscription(subId)
+        }
+        followingStreamsSubscriptionIds = []
+
+        guard !followList.isEmpty else {
+            print("ℹ️ No follow list; skipping follow-list stream subscriptions")
+            return
+        }
+
+        let pubkeys = Array(followList)
+        for chunkStart in stride(from: 0, to: pubkeys.count, by: followFilterChunkSize) {
+            let chunk = Array(pubkeys[chunkStart..<min(chunkStart + followFilterChunkSize, pubkeys.count)])
+
+            if let authorSubId = sdkClient.subscribeToStreams(authors: chunk, limit: 100) {
+                followingStreamsSubscriptionIds.append(authorSubId)
+            }
+            if let participantSubId = sdkClient.subscribeToStreams(participants: chunk, limit: 100) {
+                followingStreamsSubscriptionIds.append(participantSubId)
+            }
+        }
+
+        print("✅ Created \(followingStreamsSubscriptionIds.count) follow-list stream subscription(s) for \(pubkeys.count) pubkeys")
+    }
+
     private func createProfilesSubscription(authors: [String]) {
         guard !authors.isEmpty else {
             print("⚠️ Cannot create profiles subscription with empty author list")
@@ -303,6 +352,12 @@ class StreamViewModel: ObservableObject {
             createProfilesSubscription(authors: combinedAuthors)
         }
 
+        // Ask the relays directly for streams from the follow list. Rebuild whenever the
+        // list changes, including when it empties on logout (which tears these down).
+        if followList != previousFollowList {
+            createFollowingStreamsSubscriptions()
+        }
+
         // Re-categorize streams with new follow filter
         updateCategorizedStreams()
     }
@@ -326,6 +381,9 @@ class StreamViewModel: ObservableObject {
             sdkClient.closeSubscription(subId)
         }
         if let subId = deletionsSubscriptionId {
+            sdkClient.closeSubscription(subId)
+        }
+        for subId in followingStreamsSubscriptionIds {
             sdkClient.closeSubscription(subId)
         }
         // Deliberately does NOT call sdkClient.disconnect(): the client is the

--- a/nostrTV/StreamViewModel.swift
+++ b/nostrTV/StreamViewModel.swift
@@ -12,6 +12,10 @@ class StreamViewModel: ObservableObject {
     @Published var isLoadingAdminFollowList: Bool = true // Track if we're loading the admin follow list
     @Published var isInitialLoad: Bool = true // Track if this is the initial load (no streams received yet)
 
+    /// Size of the user's kind 3 follow list. Surfaced so the Following tab can tell
+    /// "your follow list never loaded" apart from "nobody you follow is live".
+    @Published private(set) var followListCount: Int = 0
+
     // Shared NostrSDKClient injected from the app level. Exposed internally so
     // ContentView/VideoPlayerView can pass the same instance to other managers.
     let sdkClient: NostrSDKClient
@@ -330,7 +334,8 @@ class StreamViewModel: ObservableObject {
         }
 
         // Update admin follow list
-        adminFollowList = Set(follows)
+        // Hex pubkeys are case-insensitive; normalize so comparisons cannot miss.
+        adminFollowList = Set(follows.map { $0.lowercased() })
         isLoadingAdminFollowList = false
         saveAdminFollowListToCache(follows)
 
@@ -348,7 +353,9 @@ class StreamViewModel: ObservableObject {
     /// Update user follow list (called when user logs in)
     func updateFollowList(_ newFollowList: [String]) {
         let previousFollowList = followList
-        followList = Set(newFollowList)
+        // Hex pubkeys are case-insensitive; normalize so comparisons cannot miss.
+        followList = Set(newFollowList.map { $0.lowercased() })
+        followListCount = followList.count
 
         print("🔧 User follow list updated: \(newFollowList.count) users")
 
@@ -496,7 +503,7 @@ class StreamViewModel: ObservableObject {
         if !adminFollowList.isEmpty {
             discoverStreams = cleanBase.filter { stream in
                 guard let pubkey = stream.pubkey else { return false }
-                return adminFollowList.contains(pubkey)
+                return adminFollowList.contains(pubkey.lowercased())
             }
         } else {
             discoverStreams = []
@@ -512,10 +519,10 @@ class StreamViewModel: ObservableObject {
         let followingStreams: [Stream]
         if !followList.isEmpty {
             followingStreams = cleanBase.filter { stream in
-                if let hostPubkey = stream.pubkey, followList.contains(hostPubkey) {
+                if let hostPubkey = stream.pubkey, followList.contains(hostPubkey.lowercased()) {
                     return true
                 }
-                if let authorPubkey = stream.eventAuthorPubkey, followList.contains(authorPubkey) {
+                if let authorPubkey = stream.eventAuthorPubkey, followList.contains(authorPubkey.lowercased()) {
                     return true
                 }
                 return false
@@ -524,6 +531,15 @@ class StreamViewModel: ObservableObject {
             followingStreams = []
         }
         self.categorizedStreams = categorizeStreams(followingStreams)
+
+        // Diagnostic: a blank Following tab has several possible causes, and they are
+        // indistinguishable from the UI alone. Print the inputs to the filter.
+        print("👥 Following: \(followList.count) followed pubkey(s), \(cleanBase.count) candidate stream(s) → \(followingStreams.count) match(es)")
+        if followingStreams.isEmpty && !followList.isEmpty && !cleanBase.isEmpty {
+            let candidateAuthors = Set(cleanBase.compactMap { $0.eventAuthorPubkey })
+            let candidateHosts = Set(cleanBase.compactMap { $0.pubkey })
+            print("👥 Following: no overlap between the follow list and the \(candidateAuthors.count) author(s) / \(candidateHosts.count) host(s) currently streaming")
+        }
     }
 
     private func categorizeStreams(_ streamList: [Stream]) -> [StreamCategory] {
@@ -593,7 +609,7 @@ class StreamViewModel: ObservableObject {
             do {
                 let decoder = JSONDecoder()
                 let cachedList = try decoder.decode([String].self, from: cachedData)
-                adminFollowList = Set(cachedList)
+                adminFollowList = Set(cachedList.map { $0.lowercased() })
                 isLoadingAdminFollowList = false // Cache loaded, no longer loading
                 print("✅ Loaded cached admin follow list with \(cachedList.count) users (age: \(Int(cacheAge/60)) minutes)")
 

--- a/nostrTVTests/HostPubkeyTests.swift
+++ b/nostrTVTests/HostPubkeyTests.swift
@@ -1,0 +1,88 @@
+//
+//  HostPubkeyTests.swift
+//  nostrTVTests
+//
+//  Covers resolving the host of a NIP-53 live event (kind 30311) from its tags.
+//
+//  NIP-53 defines a `p` tag as a participant entry, not specifically the host:
+//
+//      ["p", "<pubkey>", "<relay-url>", "<role>", "<proof>"]
+//
+//  with the role being a displayable marker such as Host, Speaker or Participant.
+//  Taking the first `p` tag picked a guest on multi-participant streams, which
+//  showed the wrong profile and hid the stream from the Following tab.
+//
+
+import Testing
+import Foundation
+import NostrSDK
+@testable import nostrTV
+
+struct HostPubkeyTests {
+
+    private static let host = "266815e0c9210dfa324c6cba3573b14bee49da4209a9456f9484e5106cd408a5"
+    private static let guest = "1597246ac22f7d1375041054f2a4986bd971d8d196d7997e48973263ac9879ec"
+    private static let author = "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d"
+
+    /// Tag has no public memberwise initializer, but it is publicly Decodable,
+    /// so tags are built from their wire representation.
+    private static func tags(_ raw: [[String]]) throws -> [NostrSDK.Tag] {
+        let data = try JSONSerialization.data(withJSONObject: raw)
+        return try JSONDecoder().decode([NostrSDK.Tag].self, from: data)
+    }
+
+    private static func resolve(_ raw: [[String]]) throws -> String {
+        NostrSDKClient.hostPubkey(fromTags: try tags(raw), eventAuthorPubkey: author)
+    }
+
+    @Test func prefersTheParticipantMarkedHost() throws {
+        // The guest is listed first — the Host marker must still win
+        let result = try Self.resolve([
+            ["p", Self.guest, "wss://relay.example", "Speaker"],
+            ["p", Self.host, "wss://relay.example", "Host"]
+        ])
+        #expect(result == Self.host)
+    }
+
+    @Test func matchesHostMarkerCaseInsensitively() throws {
+        let result = try Self.resolve([
+            ["p", Self.guest, "", "Participant"],
+            ["p", Self.host, "", "host"]
+        ])
+        #expect(result == Self.host)
+    }
+
+    @Test func findsHostMarkerWhenRelayURLIsOmitted() throws {
+        // Role slides to an earlier index when the relay URL is absent
+        let result = try Self.resolve([
+            ["p", Self.guest, "Speaker"],
+            ["p", Self.host, "Host"]
+        ])
+        #expect(result == Self.host)
+    }
+
+    @Test func fallsBackToFirstParticipantWhenNoHostMarker() throws {
+        let result = try Self.resolve([
+            ["p", Self.guest, "wss://relay.example"],
+            ["p", Self.host, "wss://relay.example"]
+        ])
+        #expect(result == Self.guest)
+    }
+
+    @Test func fallsBackToEventAuthorWhenNoParticipants() throws {
+        // Streams published by the host itself carry no p tag at all
+        let result = try Self.resolve([
+            ["d", "my-stream"],
+            ["status", "live"]
+        ])
+        #expect(result == Self.author)
+    }
+
+    @Test func ignoresNonParticipantTagsWhenLookingForTheHost() throws {
+        let result = try Self.resolve([
+            ["relays", "wss://one.example", "wss://two.example"],
+            ["p", Self.host, "", "Host"]
+        ])
+        #expect(result == Self.host)
+    }
+}


### PR DESCRIPTION
## Summary

Five fixes for the Following tab, which showed nothing for a logged-in user.

## 1. Following matched the wrong pubkey (`39ce326`)

Per NIP-53 a `p` tag on kind 30311 is a **participant** entry, not specifically the host:

```
["p", "<pubkey>", "<relay-url>", "<role>", "<proof>"]
```

The parser took the first `p` tag unconditionally, so on a multi-participant stream it picked a guest — showing the wrong profile, and hiding the stream from Following since that filter matches on this pubkey.

Host resolution now prefers the participant marked `Host`, falling back to the first participant and then the event signer. The marker is matched anywhere in the tag's parameters because its position varies (the relay URL is often empty or omitted). Following also matches **either** the host or the event author, since streams published by the host directly carry no `p` tag at all.

## 2. The follow list never reached a relay filter (`e2b864d`)

Following was a client-side filter over `subscribeToStreams(limit: 50)` — the 50 most recent kind 30311 events **globally**. Given stream volume, that window is easily filled by strangers, so a followed stream appeared only if it happened to be recent enough to land in it. `subscribeToStreams(authors:)` existed but had no callers.

Now subscribes for the follow list directly, rebuilt when the list changes and torn down when it empties on logout. Two filters per chunk mirroring the local match: `authors` for streams a followed user published, and `#p` for streams tagging a followed user but published by someone else.

Pubkeys are chunked at 200 per filter — follow lists run to hundreds or thousands of entries and relays impose filter-size limits, rejecting an over-large REQ silently.

## 3. Restoring a session never fetched the follow list (`27c0afd`)

`init` called `loadCachedProfile()` and stopped. `fetchUserData` — which creates the kind 3 subscription and registers the callback — ran only at login and from ProfileSettingsView. So on every later launch nothing subscribed for the user's kind 3, and an empty cache left `followList` empty forever. Curated was unaffected because the admin follow list is fetched explicitly at startup.

Both restore paths now refresh, connecting the shared pool first so the subscription isn't issued against relays that haven't begun connecting (Bug #14).

Kind 3 callbacks now also carry the **author pubkey**, and both consumers verify ownership. Every kind 3 goes to every registered callback, so without this the admin's list (fetched at startup) would overwrite the user's follow list and cache it.

## 4. Pubkey case (`3774ce2`)

Follow matching compared pubkeys as raw strings. Hex pubkeys are case-insensitive, so a kind 3 listing them in upper or mixed case matched nothing — the same silent-mismatch class as the a-tag bug. Both lists are now stored and compared lowercased.

Also adds `FollowingNoStreamsView` and a diagnostic line, because an empty Following tab rendered as a completely blank page:

```
👥 Following: N followed pubkey(s), M candidate stream(s) → K match(es)
```

## 5. Identity cycling (`6654c6f`)

Regression from #3, caught in testing. Every kind 0 is delivered to every registered profile callback, and the app subscribes to profiles for the whole follow list. The auth manager's callback accepted any arriving profile as the logged-in account and cached it — the Profile tab cycled through the people the user follows.

The callback now accepts only a profile whose pubkey matches the signed-in user. `loadCachedProfile` also discards a cached profile belonging to someone else, repairing devices where the affected build already persisted one.

## Testing

- Builds clean; 25 tests pass
- 6 new tests for host resolution, including the omitted-relay-URL case

## Not included

Chat/zap subscription churn and relay observability — split to a separate branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)