### PR TITLE
Fix live chat and zaps not streaming in

### DIFF
--- a/nostrTV/NostrSDKClient.swift
+++ b/nostrTV/NostrSDKClient.swift
@@ -469,6 +469,13 @@ class NostrSDKClient {
                 self?.handleRelayEvent(relayEvent)
             }
             .store(in: &cancellables)
+
+        // The events publisher only carries EVENT messages. Everything a relay says
+        // about the health of a subscription — CLOSED, NOTICE, OK, EOSE — and every
+        // connection state change arrives via the delegate instead. Without it a relay
+        // terminating a subscription is completely invisible: events simply stop, with
+        // no error anywhere. Observing it makes those failures diagnosable.
+        relayPool.delegate = self
     }
 
     /// Route incoming relay events to appropriate handlers based on event kind
@@ -1513,5 +1520,72 @@ extension Array {
         return stride(from: 0, to: count, by: size).map {
             Array(self[$0..<Swift.min($0 + size, count)])
         }
+    }
+}
+
+// MARK: - RelayDelegate
+
+/// Observes relay control messages and connection state.
+///
+/// `RelayPool.events` only publishes EVENT messages, so without this the app is blind
+/// to everything else a relay says. In particular a relay that closes one of our
+/// subscriptions (CLOSED) produces no error and no callback — events just stop
+/// arriving, which is indistinguishable from a quiet stream. Subscription-scoped
+/// messages are logged with the subscription's purpose so it is obvious which feature
+/// went silent.
+extension NostrSDKClient: RelayDelegate {
+
+    func relayStateDidChange(_ relay: Relay, state: Relay.State) {
+        switch state {
+        case .connected:
+            print("🔗 Relay connected: \(relay.url.absoluteString)")
+        case .connecting:
+            print("🔄 Relay connecting: \(relay.url.absoluteString)")
+        case .notConnected:
+            print("🔌 Relay disconnected: \(relay.url.absoluteString)")
+        case .error(let error):
+            print("❌ Relay error (\(relay.url.absoluteString)): \(error.localizedDescription)")
+        @unknown default:
+            print("❔ Relay state changed (\(relay.url.absoluteString)): \(String(describing: state))")
+        }
+    }
+
+    func relay(_ relay: Relay, didReceive response: RelayResponse) {
+        switch response {
+        case .closed(let subscriptionId, let message):
+            // The relay has terminated this subscription: no further events will
+            // arrive on it until we resubscribe.
+            print("🚫 Relay \(relay.url.absoluteString) CLOSED subscription \(subscriptionId) "
+                  + "(purpose: \(purpose(forSubscriptionId: subscriptionId))): \(message)")
+
+        case .notice(let message):
+            print("📢 Relay notice (\(relay.url.absoluteString)): \(message)")
+
+        case .eose(let subscriptionId):
+            print("📭 Relay \(relay.url.absoluteString) end of stored events for \(subscriptionId) "
+                  + "(purpose: \(purpose(forSubscriptionId: subscriptionId))) — live events follow")
+
+        case .ok(let eventId, let success, let message):
+            if !success {
+                print("❌ Relay \(relay.url.absoluteString) rejected event \(eventId.prefix(8))…: \(message)")
+            }
+
+        case .auth(let challenge):
+            print("🔐 Relay \(relay.url.absoluteString) requested AUTH (challenge: \(challenge.prefix(12))…) — not implemented")
+
+        case .event, .count:
+            break  // Events flow through the events publisher
+        }
+    }
+
+    func relay(_ relay: Relay, didReceive event: RelayEvent) {
+        // Handled via the events publisher in setupEventStream()
+    }
+
+    /// Human-readable purpose for a subscription, for logging.
+    private func purpose(forSubscriptionId subscriptionId: String) -> String {
+        subscriptionsLock.lock()
+        defer { subscriptionsLock.unlock() }
+        return activeSubscriptions[subscriptionId]?.purpose ?? "unknown"
     }
 }

--- a/nostrTV/NostrSDKClient.swift
+++ b/nostrTV/NostrSDKClient.swift
@@ -301,7 +301,6 @@ class NostrSDKClient {
     /// - Parameter urls: Relay URLs to ensure are present in the pool.
     func addRelays(_ urls: [String]) {
         let existingURLs = Set(relayPool.relays.map { $0.url.absoluteString })
-        var addedAny = false
 
         for urlString in urls {
             guard let url = URL(string: urlString),
@@ -310,20 +309,14 @@ class NostrSDKClient {
             do {
                 let relay = try Relay(url: url)
                 relayPool.add(relay: relay)
-                addedAny = true
                 print("🔌 NostrSDKClient: Added stream relay \(url.absoluteString)")
             } catch {
                 print("⚠️ NostrSDKClient: Skipping invalid stream relay \(urlString): \(error.localizedDescription)")
             }
         }
 
-        guard addedAny else { return }
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
-            guard let self = self else { return }
-            print("🔄 NostrSDKClient: Re-emitting subscriptions to newly added relays")
-            self.resubscribeAll()
-        }
+        // No follow-up needed: each newly added relay receives the active
+        // subscriptions from relayStateDidChange once its socket is connected.
     }
 
     /// Disconnect from all relays.
@@ -439,6 +432,31 @@ class NostrSDKClient {
     }
 
     /// Resubscribe to all previously active subscriptions using stored filter state
+    /// Re-emit every active subscription to a single relay.
+    ///
+    /// Used when a relay reports `.connected`, so subscriptions created while it was
+    /// down are established rather than silently lost. Re-sending a REQ with an
+    /// existing subscription ID is idempotent — the relay replaces it.
+    private func resubscribeAll(to relay: Relay) {
+        subscriptionsLock.lock()
+        let subscriptionsToRestore = activeSubscriptions
+        subscriptionsLock.unlock()
+
+        guard !subscriptionsToRestore.isEmpty else { return }
+
+        var restored = 0
+        for (_, stored) in subscriptionsToRestore {
+            do {
+                _ = try relay.subscribe(with: stored.filter, subscriptionId: stored.id)
+                restored += 1
+            } catch {
+                print("⚠️ NostrSDKClient: Could not restore '\(stored.purpose)' on \(relay.url.absoluteString): \(error.localizedDescription)")
+            }
+        }
+
+        print("🔄 NostrSDKClient: Restored \(restored)/\(subscriptionsToRestore.count) subscription(s) on \(relay.url.absoluteString)")
+    }
+
     private func resubscribeAll() {
         subscriptionsLock.lock()
         let subscriptionsToRestore = activeSubscriptions
@@ -1539,6 +1557,14 @@ extension NostrSDKClient: RelayDelegate {
         switch state {
         case .connected:
             print("🔗 Relay connected: \(relay.url.absoluteString)")
+            // Re-emit our subscriptions to this relay now that its socket is actually
+            // up. RelayPool.subscribe fans out to every relay at call time and drops
+            // any that are not yet connected — Relay.subscribe throws .notConnected and
+            // the pool only logs it — so a relay that finishes its handshake after a
+            // subscription was created would otherwise never receive it, and nothing
+            // retried. Driving this off the connection event instead of a fixed delay
+            // is what makes recovery reliable.
+            resubscribeAll(to: relay)
         case .connecting:
             print("🔄 Relay connecting: \(relay.url.absoluteString)")
         case .notConnected:

--- a/nostrTV/StreamActivityManager.swift
+++ b/nostrTV/StreamActivityManager.swift
@@ -45,17 +45,30 @@ class StreamActivityManager: ObservableObject {
             return
         }
 
-        // Guard against double-start: if already listening, stop first to prevent
-        // duplicate subscriptions and stale callbacks. This handles the case where
-        // onAppear fires without a prior onDisappear (e.g. fullScreenCover reuse).
+        let requestedATag = ATag.construct(pubkey: authorPubkey, dTag: stream.streamID)
+
+        // Already listening to this exact stream: do nothing.
+        //
+        // This must be a no-op rather than a restart. VideoPlayerView calls this from
+        // onAppear, which fires repeatedly while the player is open — device logs
+        // showed ten distinct chat-zaps subscriptions inside ten minutes. Restarting
+        // tears down the live subscription and clears chatMessages/zapComments, so
+        // arriving messages were wiped every ~30 seconds and chat only ever showed
+        // the batch of stored events fetched right after (re)entering the stream.
+        if subscriptionId != nil, currentStreamATag == requestedATag {
+            print("📺 StreamActivityManager: Already listening to \(stream.streamID); keeping the existing subscription")
+            return
+        }
+
+        // Switching to a different stream: tear the old subscription down first.
         if subscriptionId != nil {
-            print("📺 StreamActivityManager: Already listening, stopping previous subscription before restart")
+            print("📺 StreamActivityManager: Switching streams, stopping previous subscription")
             stopListening()
         }
 
         self.nostrClient = client
-        self.currentStreamATag = ATag.construct(pubkey: authorPubkey, dTag: stream.streamID)
-        let aTag = currentStreamATag!
+        self.currentStreamATag = requestedATag
+        let aTag = requestedATag
 
         // Join the stream's own relays before subscribing. Chat (1311) and zap
         // receipts (9735) are usually published only there, not to our default

--- a/nostrTV/VideoPlayerView.swift
+++ b/nostrTV/VideoPlayerView.swift
@@ -258,11 +258,11 @@ struct VideoPlayerView: View {
 
             // Start listening for chat and zaps (combined subscription)
             if let stream = stream {
-                // Defensive cleanup: stop any stale subscription from a previous stream
-                // before starting a new one. onDisappear is not guaranteed to fire before
-                // the next onAppear when fullScreenCover is dismissed and re-presented,
-                // so this prevents duplicate/stale subscriptions from accumulating.
-                activityManager.stopListening()
+                // Do NOT stop first. onAppear fires repeatedly while the player is open,
+                // and an unconditional stop/start cycle destroyed the live subscription
+                // and cleared the message buffers every time — chat never accumulated.
+                // startListening is idempotent: it no-ops when already listening to this
+                // stream and tears down the old subscription only when switching streams.
                 activityManager.startListening(for: stream, using: nostrSDKClient)
             }
 


### PR DESCRIPTION
## Summary

Comments and zaps arrived once and then stopped; the only way to see new ones was to leave the stream and re-open it. **Verified fixed** by @tkhumush with a live comment from a second account.

Two independent causes, both found from device logs.

## 1. Subscriptions were lost on every reconnect (`ce28778`) — the primary cause

Logs showed bursts of **78–156** `There is no connection to the relay web socket` errors within a single minute, then quiet, then another burst — from *every* relay, including healthy ones.

`performReconnection()` disconnects the whole pool, waits a **fixed 2 seconds**, then re-emits every subscription if *any* relay reports connected. Relays still completing their handshake reject all of them, `RelayPool` only logs the failure, and nothing retries. The app then receives nothing, the 60-second silence check fires, and it reconnects again — self-reinforcing.

Subscriptions are now re-emitted **per relay** from `relayStateDidChange` when that relay reports `.connected`, using `Relay.subscribe` directly. Re-sending a REQ with an existing subscription ID is idempotent. `addRelays` no longer needs its own fixed delay — the same event covers newly added relays.

## 2. The chat subscription was rebuilt every ~30 seconds (`62b9f29`)

Logs showed **ten distinct `chat-zaps` subscription IDs in ten minutes**. `VideoPlayerView.onAppear` ran `stopListening()` then `startListening()` unconditionally, and `onAppear` fires repeatedly while the player is open. `stopListening` closes the subscription **and clears `chatMessages`/`zapComments`**, so the buffer was wiped on every cycle.

`startListening` is now idempotent — it no-ops when already listening to the same stream and tears down only when switching streams. The unconditional stop in `onAppear` is removed.

## 3. Relay control messages are now observed (`70b8b34`)

`RelayPool.events` only publishes EVENT messages and no `RelayDelegate` was set, so `CLOSED`, `NOTICE`, `OK`, `EOSE` and connection state changes were all invisible — a relay terminating a subscription looked identical to a quiet stream. `NostrSDKClient` now conforms to `RelayDelegate` and logs these, resolving subscription IDs to their stored purpose.

This is also what made fix #1 possible: the connection event is the signal that replaced the fixed-delay guess.

## Testing

- Builds clean; 25 tests pass; no new warnings
- Live-verified: a comment posted from a second account appeared without reopening the stream

## Known issue, not addressed here

`relay.damus.io` fails its WebSocket handshake (`-1011`) and `relay.tunestr.io` times out (`-1001`), repeatedly. Those failures are what trigger the reconnect cycles. They are now survivable rather than fatal, but removing or replacing those two defaults would reduce churn considerably.

🤖 Generated with [Claude Code](https://claude.com/claude-code)